### PR TITLE
Better defaults for LTXV

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Then launch LoRA fine-tuning. Below we provide an example for LTX-Video. We refe
 <details>
 <summary>Training command</summary>
 
+TODO: LTX does not do too well with the disney dataset. We will update this to use a better example soon.
+
 ```bash
 #!/bin/bash
 export WANDB_MODE="offline"
@@ -75,18 +77,18 @@ dataset_cmd="--data_root $DATA_ROOT \
 dataloader_cmd="--dataloader_num_workers 0"
 
 # Diffusion arguments
-diffusion_cmd="--flow_resolution_shifting"
+diffusion_cmd="--flow_weighting_scheme logit_normal"
 
 # Training arguments
 training_cmd="--training_type lora \
   --seed 42 \
   --mixed_precision bf16 \
   --batch_size 1 \
-  --train_steps 1200 \
+  --train_steps 3000 \
   --rank 128 \
   --lora_alpha 128 \
   --target_modules to_q to_k to_v to_out.0 \
-  --gradient_accumulation_steps 1 \
+  --gradient_accumulation_steps 4 \
   --gradient_checkpointing \
   --checkpointing_steps 500 \
   --checkpointing_limit 2 \

--- a/docs/training/ltx_video.md
+++ b/docs/training/ltx_video.md
@@ -36,18 +36,18 @@ dataset_cmd="--data_root $DATA_ROOT \
 dataloader_cmd="--dataloader_num_workers 0"
 
 # Diffusion arguments
-diffusion_cmd="--flow_resolution_shifting"
+diffusion_cmd="--flow_weighting_scheme logit_normal"
 
 # Training arguments
 training_cmd="--training_type lora \
   --seed 42 \
   --mixed_precision bf16 \
   --batch_size 1 \
-  --train_steps 1200 \
+  --train_steps 3000 \
   --rank 128 \
   --lora_alpha 128 \
   --target_modules to_q to_k to_v to_out.0 \
-  --gradient_accumulation_steps 1 \
+  --gradient_accumulation_steps 4 \
   --gradient_checkpointing \
   --checkpointing_steps 500 \
   --checkpointing_limit 2 \


### PR DESCRIPTION
The major change is that we using logit_normal weighting as described in the paper. We did not know this detail beforehand when LTXV support was added leading to suboptimal loss.