### PR TITLE
Update pr_tests.yml to update ruff version

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install ruff==0.1.5
       - name: Check quality
         run: make quality
       - name: Check if failure


### PR DESCRIPTION
We use this version in `diffusers`. Will unblock https://github.com/a-r-r-o-w/finetrainers/actions/runs/12701999964/workflow?pr=202.