### PR TITLE
Fix the checkpoint dir bug in `get_intermediate_ckpt_path`

### DIFF
--- a/finetrainers/utils/checkpointing.py
+++ b/finetrainers/utils/checkpointing.py
@@ -55,7 +55,7 @@ def get_intermediate_ckpt_path(checkpointing_limit: int, step: int, output_dir: 
         # before we save the new checkpoint, we need to have at_most `checkpoints_total_limit - 1` checkpoints
         if len(checkpoints) >= checkpointing_limit:
             num_to_remove = len(checkpoints) - checkpointing_limit + 1
-            checkpoints_to_remove = checkpoints[0:num_to_remove]
+            checkpoints_to_remove = [os.path.join(output_dir, x) for x in checkpoints[0:num_to_remove]]
             delete_files(checkpoints_to_remove)
 
     logger.info(f"Checkpointing at step {step}")


### PR DESCRIPTION
Currently, the checkpoint dirs scanned only have the folder names not full paths. So, `delete_files` won't delete anything if `output_dir` is any non-empty path. Just a very simple fix to make checkpointing_limit work robustly.