### PR TITLE
[Chore] reset unnecessary args

### DIFF
--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -484,7 +484,7 @@ def validate_args(args: Args):
     _validated_model_args(args)
     _validate_training_args(args)
     _validate_validation_args(args)
-    _maybe_purge_unnecessary_args(args)
+    _maybe_reset_unnecessary_args(args)
 
 
 def _add_model_arguments(parser: argparse.ArgumentParser) -> None:
@@ -1185,7 +1185,7 @@ def _validate_validation_args(args: Args):
     ), "Validation prompts and widths should be of same length"
 
 
-def _maybe_purge_unnecessary_args(args: Args):
+def _maybe_reset_unnecessary_args(args: Args):
     if args.training_type == "full-finetune":
         if args.rank:
             setattr(args, "rank", None)

--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -484,6 +484,7 @@ def validate_args(args: Args):
     _validated_model_args(args)
     _validate_training_args(args)
     _validate_validation_args(args)
+    _maybe_purge_unnecessary_args(args)
 
 
 def _add_model_arguments(parser: argparse.ArgumentParser) -> None:
@@ -1182,6 +1183,16 @@ def _validate_validation_args(args: Args):
     assert len(args.validation_prompts) == len(
         args.validation_widths
     ), "Validation prompts and widths should be of same length"
+
+
+def _maybe_purge_unnecessary_args(args: Args):
+    if args.training_type == "full-finetune":
+        if args.rank:
+            setattr(args, "rank", None)
+        if args.lora_alpha:
+            setattr(args, "lora_alpha", None)
+        if args.target_modules:
+            setattr(args, "target_modules", None)
 
 
 def _display_helper_messages(args: argparse.Namespace):

--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -484,7 +484,6 @@ def validate_args(args: Args):
     _validated_model_args(args)
     _validate_training_args(args)
     _validate_validation_args(args)
-    _maybe_reset_unnecessary_args(args)
 
 
 def _add_model_arguments(parser: argparse.ArgumentParser) -> None:
@@ -1183,16 +1182,6 @@ def _validate_validation_args(args: Args):
     assert len(args.validation_prompts) == len(
         args.validation_widths
     ), "Validation prompts and widths should be of same length"
-
-
-def _maybe_reset_unnecessary_args(args: Args):
-    if args.training_type == "full-finetune":
-        if args.rank:
-            setattr(args, "rank", None)
-        if args.lora_alpha:
-            setattr(args, "lora_alpha", None)
-        if args.target_modules:
-            setattr(args, "target_modules", None)
 
 
 def _display_helper_messages(args: argparse.Namespace):

--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -1164,17 +1164,27 @@ class Trainer:
     def _get_training_info(self) -> dict:
         args = self.args.to_dict()
 
-        # Filter LoRA-related arguments based on training type
-        if args.get("training_type") == "full-finetune":
-            training_info = {k: v for k, v in args.items() if k not in {"rank", "lora_alpha", "target_modules"}}
-        else:
-            training_info = args.copy()
+        training_args = args.get("training_arguments", {})
+        training_type = training_args.get("training_type", "")
 
-        # Adjust diffusion/flow-related arguments
+        # LoRA/non-LoRA stuff.
+        if training_type == "full-finetune":
+            filtered_training_args = {
+                k: v for k, v in training_args.items() if k not in {"rank", "lora_alpha", "target_modules"}
+            }
+        else:
+            filtered_training_args = training_args
+
+        # Diffusion/flow stuff.
+        diffusion_args = args.get("diffusion_arguments", {})
         scheduler_name = self.scheduler.__class__.__name__
         if scheduler_name != "FlowMatchEulerDiscreteScheduler":
-            updated_training_info = {k: v for k, v in training_info.items() if "flow" not in k}
+            filtered_diffusion_args = {k: v for k, v in diffusion_args.items() if "flow" not in k}
         else:
-            updated_training_info = training_info
+            filtered_diffusion_args = diffusion_args
 
+        # Rest of the stuff.
+        updated_training_info = args.copy()
+        updated_training_info["training_arguments"] = filtered_training_args
+        updated_training_info["diffusion_arguments"] = filtered_diffusion_args
         return updated_training_info


### PR DESCRIPTION
When `training_type == "full-finetune"`, I think we should reset the default values of LoRA related args like `lora_alpha`, `rank`, etc. Otherwise, the logged args in the tracker might be confusing for the users. 

No need to explain if this is not right, I will close the PR. Thought of directly opening a PR as it was easier and not time-consuming at all.

Example overview: https://wandb.ai/sayakpaul/finetrainers-cog/runs/t1c5jcj3/overview. 