### PR TITLE
[core] fix pipeline loading by waiting till `transformer` is saved.

### DIFF
--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -955,19 +955,14 @@ class Trainer:
             tracker_key = "final" if final_validation else "validation"
             for tracker in accelerator.trackers:
                 if tracker.name == "wandb":
-                    image_artifacts = [artifact for artifact in all_artifacts if isinstance(artifact, wandb.Image)]
-                    video_artifacts = [artifact for artifact in all_artifacts if isinstance(artifact, wandb.Video)]
-                    image_dict = None
-                    video_dict = None
                     artifact_log_dict = {}
+
+                    image_artifacts = [artifact for artifact in all_artifacts if isinstance(artifact, wandb.Image)]
                     if image_artifacts:
-                        image_dict = {"images": image_artifacts}
+                        artifact_log_dict["images"] = image_artifacts
+                    video_artifacts = [artifact for artifact in all_artifacts if isinstance(artifact, wandb.Video)]
                     if video_artifacts:
-                        video_dict = {"videos": video_artifacts}
-                    if image_dict:
-                        artifact_log_dict.update(image_dict)
-                    if video_dict:
-                        artifact_log_dict.update(video_dict)
+                        artifact_log_dict["videos"] = video_artifacts
                     tracker.log({tracker_key: artifact_log_dict}, step=step)
             
             if self.args.push_to_hub and final_validation:

--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -958,10 +958,10 @@ class Trainer:
                     artifact_log_dict = {}
 
                     image_artifacts = [artifact for artifact in all_artifacts if isinstance(artifact, wandb.Image)]
-                    if image_artifacts:
+                    if len(image_artifacts) > 0:
                         artifact_log_dict["images"] = image_artifacts
                     video_artifacts = [artifact for artifact in all_artifacts if isinstance(artifact, wandb.Video)]
-                    if video_artifacts:
+                    if len(video_artifacts) > 0:
                         artifact_log_dict["videos"] = video_artifacts
                     tracker.log({tracker_key: artifact_log_dict}, step=step)
 

--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -964,7 +964,7 @@ class Trainer:
                     if video_artifacts:
                         artifact_log_dict["videos"] = video_artifacts
                     tracker.log({tracker_key: artifact_log_dict}, step=step)
-            
+
             if self.args.push_to_hub and final_validation:
                 video_filenames = list(prompts_to_filenames.values())
                 prompts = list(prompts_to_filenames.keys())


### PR DESCRIPTION
Currently, we first wait for all processes to complete before saving the final state dict (which happens under the main process). We then proceed towards distributed validation. The nuance of this is that distributed validation can start even before the state dict serialization is complete. 

Below is a snippet of the problem:

<details>
<summary>Unfold</summary>

```bash
ERROR:finetrainers:Traceback (most recent call last):
  File "/fsx/sayak/finetrainers/train.py", line 35, in main
    trainer.train()
  File "/fsx/sayak/finetrainers/finetrainers/trainer.py", line 844, in train
    self.validate(step=global_step, final_validation=True)
  File "/fsx/sayak/finetrainers/finetrainers/trainer.py", line 873, in validate
    pipeline = self._get_and_prepare_pipeline_for_validation(final_validation=final_validation)
  File "/fsx/sayak/finetrainers/finetrainers/trainer.py", line 1134, in _get_and_prepare_pipeline_for_validation
    transformer = self.model_config["load_diffusion_models"](model_id=self.args.output_dir)["transformer"]
  File "/fsx/sayak/finetrainers/finetrainers/models/cogvideox/lora.py", line 45, in load_diffusion_models
    transformer = CogVideoXTransformer3DModel.from_pretrained(
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/fsx/sayak/diffusers/src/diffusers/models/modeling_utils.py", line 857, in from_pretrained
    model_file = _get_model_file(
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/fsx/sayak/diffusers/src/diffusers/utils/hub_utils.py", line 309, in _get_model_file
    raise EnvironmentError(
OSError: Error no file named diffusion_pytorch_model.bin found in directory cogvideox-news-anchoring.
```

</details>

This PR fixes the problem.

The other changes are regarding fixing unneeded media:
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/76e1a158-65f8-4c5a-942a-281058fce3d8" />

Fixed: https://wandb.ai/sayakpaul/finetrainers-cog/runs/l5raemd
<img width="1381" alt="image" src="https://github.com/user-attachments/assets/2e3ee71f-3fb7-410c-be21-53320c26ab19" />

Completely okay for me if you want me to separate the other changes.