### PR TITLE
fix(typo): captions path in disney dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export FINETRAINERS_LOG_LEVEL=DEBUG
 GPU_IDS="0,1"
 
 DATA_ROOT="/path/to/video-dataset-disney"
-CAPTION_COLUMN="prompts.txt"
+CAPTION_COLUMN="prompt.txt"
 VIDEO_COLUMN="videos.txt"
 OUTPUT_DIR="/path/to/output/directory/ltx-video/ltxv_disney"
 

--- a/training/train_image_to_video_sft.sh
+++ b/training/train_image_to_video_sft.sh
@@ -22,7 +22,7 @@ ACCELERATE_CONFIG_FILE="accelerate_configs/deepspeed.yaml"
 # This example assumes you downloaded an already prepared dataset from HF CLI as follows:
 #   huggingface-cli download --repo-type dataset Wild-Heart/Disney-VideoGeneration-Dataset --local-dir /path/to/my/datasets/disney-dataset
 DATA_ROOT="/path/to/my/datasets/video-dataset-disney"
-CAPTION_COLUMN="prompts.txt"
+CAPTION_COLUMN="prompt.txt"
 VIDEO_COLUMN="videos.txt"
 MODEL_PATH="THUDM/CogVideoX1.5-5B-I2V"
 


### PR DESCRIPTION
the example dataset id provided in the README ([Wild-Heart/Disney-VideoGeneration-Dataset](https://huggingface.co/datasets/Wild-Heart/Disney-VideoGeneration-Dataset)) has caption path as `prompt.txt` (see [captions file](https://huggingface.co/datasets/Wild-Heart/Disney-VideoGeneration-Dataset/blob/823c1f015e7ced7fffb8ad44881f792195114386/prompt.txt))  but README and related training scripts uses `prompts.txt`

