### PR TITLE
fix tests, small optimization to json dataset loading

### DIFF
--- a/assets/tests/dummy_json_dataset.json
+++ b/assets/tests/dummy_json_dataset.json
@@ -1,0 +1,7 @@
+[{
+    "path": "videos/hiker.mp4",
+    "caption": "This is a test caption"
+},{
+    "path": "videos/hiker_tiny.mp4",
+    "caption": "This is another test caption"
+}]

--- a/finetrainers/dataset.py
+++ b/finetrainers/dataset.py
@@ -246,7 +246,7 @@ class ImageOrVideoDataset(Dataset):
         video_reader = decord.VideoReader(uri=path.as_posix())
         video_num_frames = len(video_reader)
 
-        indices = list(range(0, video_num_frames))
+        indices = list(range(0, video_num_frames, video_num_frames // self.max_num_frames))
         frames = video_reader.get_batch(indices)
         frames = frames[: self.max_num_frames].float()
         frames = frames.permute(0, 3, 1, 2).contiguous()


### PR DESCRIPTION
This fixes the dataset tests that were referencing the old cogvideox repo.
I also noticed while doing so that using ImageOrVideoDataset directly will throw an exception because max_num_frames is not set. So I moved that to __init__ of the base class.

There's also a minor refactor to the _load_dataset_from_json method, because I initially read it wrong and thought it was parsing two columns separately. At least it only parses the data once.

I still haven't done any test run with this. So maybe let it simmer for a bit.

Ref: #239 