### PR TITLE
Model Specification API

### DIFF
--- a/finetrainers/conditions/__init__.py
+++ b/finetrainers/conditions/__init__.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from typing import Any, Dict
+
+from ..utils import get_parameter_names
+from .condition_utils import Condition, get_condition_parameters_from_dict
+from .text import CaptionEmbeddingDropoutCondition, CaptionTextDropoutCondition, T5Condition
+
+
+class ConditionType(str, Enum):
+    # Text conditions
+    CLIP = "clip"
+    T5 = "t5"
+
+    # Dropout conditions
+    CAPTION_TEXT_DROPOUT = "caption_text_dropout"
+    CAPTION_EMBEDDING_DROPOUT = "caption_embedding_dropout"
+
+
+SUPPORTED_CONDITIONS = {condition_type.value for condition_type in ConditionType.__members__.values()}
+
+# fmt: off
+_CONDITION_TYPE_TO_CONDITION_MAPPING = {
+    # Text conditions
+    ConditionType.T5: T5Condition,
+
+    # Dropout conditions
+    ConditionType.CAPTION_EMBEDDING_DROPOUT: CaptionEmbeddingDropoutCondition,
+    ConditionType.CAPTION_TEXT_DROPOUT: CaptionTextDropoutCondition,
+}
+# fmt: on
+
+
+def get_condition_cls(condition_type: ConditionType) -> Condition:
+    return _CONDITION_TYPE_TO_CONDITION_MAPPING[condition_type]
+
+
+def get_condition(condition_type: ConditionType, condition_parameters: Dict[str, Any]) -> Condition:
+    condition_cls = get_condition_cls(condition_type)
+    accepted_parameters = get_parameter_names(condition_cls.__init__)
+    condition_parameters = get_condition_parameters_from_dict(accepted_parameters, condition_parameters)
+    return condition_cls(**condition_parameters)

--- a/finetrainers/conditions/condition_utils.py
+++ b/finetrainers/conditions/condition_utils.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict, Set
+
+
+class Condition:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def __call__(self, *args, **kwargs) -> None:
+        raise NotImplementedError(f"Condition::__call__ is not implemented for {self.__class__.__name__}")
+
+
+def get_condition_parameters_from_dict(accepted_parameters: Set[str], parameters: Dict[str, Any]) -> Dict[str, Any]:
+    return {k: v for k, v in parameters.items() if k in accepted_parameters}

--- a/finetrainers/conditions/text.py
+++ b/finetrainers/conditions/text.py
@@ -1,0 +1,59 @@
+from typing import Dict, List, Optional, Union
+
+import torch
+from transformers import T5EncoderModel, T5Tokenizer, T5TokenizerFast
+
+from .. import functional as FF
+from .condition_utils import Condition
+
+
+class CaptionEmbeddingDropoutCondition(Condition):
+    def __init__(self, dropout_p: float = 0.0) -> None:
+        self.dropout_p = dropout_p
+
+    def __call__(self, embedding: torch.Tensor, masks: Optional[List[torch.BoolTensor]] = None) -> torch.Tensor:
+        return FF.dropout_embeddings_to_zero(embedding, masks, self.dropout_p)
+
+
+class CaptionTextDropoutCondition(Condition):
+    def __init__(self, dropout_p: float = 0.0) -> None:
+        self.dropout_p = dropout_p
+
+    def __call__(self, text: Union[str, List[str]]) -> Union[str, List[str]]:
+        return FF.dropout_text(text, self.dropout_p)
+
+
+class T5Condition(Condition):
+    def __init__(
+        self,
+        tokenizer: Union[T5Tokenizer, T5TokenizerFast],
+        text_encoder: T5EncoderModel,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.text_encoder = text_encoder
+
+    def __call__(self, text: Union[str, List[str]], max_sequence_length: int) -> Dict[str, torch.Tensor]:
+        if isinstance(text, str):
+            text = [text]
+
+        device = self.text_encoder.device
+        dtype = self.text_encoder.dtype
+
+        batch_size = len(text)
+        text_inputs = self.tokenizer(
+            text,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            add_special_tokens=True,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids
+        prompt_attention_mask = text_inputs.attention_mask
+        prompt_attention_mask = prompt_attention_mask.bool().to(device)
+
+        prompt_embeds = self.text_encoder(text_input_ids.to(device))[0]
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+        prompt_attention_mask = prompt_attention_mask.view(batch_size, -1)
+
+        return {"prompt_embeds": prompt_embeds, "prompt_attention_mask": prompt_attention_mask}

--- a/finetrainers/functional/__init__.py
+++ b/finetrainers/functional/__init__.py
@@ -1,0 +1,2 @@
+from .diffusion import flow_match_target, flow_match_xt
+from .preprocessing import dropout_embeddings_to_zero, dropout_text

--- a/finetrainers/functional/diffusion.py
+++ b/finetrainers/functional/diffusion.py
@@ -1,0 +1,11 @@
+import torch
+
+
+def flow_match_xt(x0: torch.Tensor, n: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+    r"""Forward process of flow matching."""
+    return (1.0 - t) * x0 + t * n
+
+
+def flow_match_target(n: torch.Tensor, x0: torch.Tensor) -> torch.Tensor:
+    r"""Loss target for flow matching."""
+    return n - x0

--- a/finetrainers/functional/preprocessing.py
+++ b/finetrainers/functional/preprocessing.py
@@ -1,0 +1,25 @@
+import random
+from typing import List, Optional, Union
+
+import torch
+
+
+def dropout_text(text: Union[str, List[str]], dropout_p: float = 0) -> Union[str, List[str]]:
+    if random.random() >= dropout_p:
+        return text
+    if isinstance(text, str):
+        return ""
+    return [""] * len(text)
+
+
+def dropout_embeddings_to_zero(
+    embed: torch.Tensor,
+    masks: Optional[List[torch.BoolTensor]] = None,
+    dropout_p: float = 0,
+) -> torch.Tensor:
+    if random.random() >= dropout_p:
+        return embed
+    embed = torch.zeros_like(embed)
+    if masks is not None:
+        masks = [torch.zeros_like(mask, dtype=torch.bool) for mask in masks]
+    return embed, masks

--- a/finetrainers/models/__init__.py
+++ b/finetrainers/models/__init__.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict
+from typing import Any, Dict, Type
 
 from .cogvideox import COGVIDEOX_T2V_FULL_FINETUNE_CONFIG, COGVIDEOX_T2V_LORA_CONFIG
 from .hunyuan_video import HUNYUAN_VIDEO_T2V_FULL_FINETUNE_CONFIG, HUNYUAN_VIDEO_T2V_LORA_CONFIG
-from .ltx_video import LTX_VIDEO_T2V_FULL_FINETUNE_CONFIG, LTX_VIDEO_T2V_LORA_CONFIG
+from .ltx_video import LTX_VIDEO_T2V_FULL_FINETUNE_CONFIG, LTX_VIDEO_T2V_LORA_CONFIG, LTXVideoModelSpecification
+from .modeling_utils import ModelSpecification
 
 
 SUPPORTED_MODEL_CONFIGS = {
@@ -11,8 +12,10 @@ SUPPORTED_MODEL_CONFIGS = {
         "full-finetune": HUNYUAN_VIDEO_T2V_FULL_FINETUNE_CONFIG,
     },
     "ltx_video": {
-        "lora": LTX_VIDEO_T2V_LORA_CONFIG,
-        "full-finetune": LTX_VIDEO_T2V_FULL_FINETUNE_CONFIG,
+        "lora": LTXVideoModelSpecification,
+        "full-finetune": LTXVideoModelSpecification,
+        # "lora": LTX_VIDEO_T2V_LORA_CONFIG,
+        # "full-finetune": LTX_VIDEO_T2V_FULL_FINETUNE_CONFIG,
     },
     "cogvideox": {
         "lora": COGVIDEOX_T2V_LORA_CONFIG,
@@ -21,7 +24,7 @@ SUPPORTED_MODEL_CONFIGS = {
 }
 
 
-def get_config_from_model_name(model_name: str, training_type: str) -> Dict[str, Any]:
+def get_model_specifiction_cls(model_name: str, training_type: str) -> Type[ModelSpecification]:
     if model_name not in SUPPORTED_MODEL_CONFIGS:
         raise ValueError(
             f"Model {model_name} not supported. Supported models are: {list(SUPPORTED_MODEL_CONFIGS.keys())}"

--- a/finetrainers/models/ltx_video/__init__.py
+++ b/finetrainers/models/ltx_video/__init__.py
@@ -1,2 +1,3 @@
 from .full_finetune import LTX_VIDEO_T2V_FULL_FINETUNE_CONFIG
 from .lora import LTX_VIDEO_T2V_LORA_CONFIG
+from .specification_sft import LTXVideoModelSpecification

--- a/finetrainers/models/ltx_video/specification_sft.py
+++ b/finetrainers/models/ltx_video/specification_sft.py
@@ -1,0 +1,356 @@
+from typing import Dict, List, Optional, Tuple
+
+import torch
+from diffusers import AutoencoderKLLTXVideo, FlowMatchEulerDiscreteScheduler, LTXPipeline, LTXVideoTransformer3DModel
+from transformers import AutoModel, AutoTokenizer, T5EncoderModel, T5Tokenizer
+
+from ... import functional as FF
+from ...utils import get_non_null_items
+from ..modeling_utils import ModelSpecification
+
+
+class LTXVideoModelSpecification(ModelSpecification):
+    pipeline_cls = LTXPipeline
+
+    def __init__(
+        self,
+        pretrained_model_name_or_path: str = "Lightricks/LTX-Video",
+        tokenizer_id: Optional[str] = None,
+        text_encoder_id: Optional[str] = None,
+        transformer_id: Optional[str] = None,
+        vae_id: Optional[str] = None,
+        text_encoder_dtype: torch.dtype = torch.bfloat16,
+        transformer_dtype: torch.dtype = torch.bfloat16,
+        vae_dtype: torch.dtype = torch.bfloat16,
+        revision: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            tokenizer_id=tokenizer_id,
+            text_encoder_id=text_encoder_id,
+            transformer_id=transformer_id,
+            vae_id=vae_id,
+            text_encoder_dtype=text_encoder_dtype,
+            transformer_dtype=transformer_dtype,
+            vae_dtype=vae_dtype,
+            revision=revision,
+            cache_dir=cache_dir,
+        )
+
+    def load_condition_models(self, *args, **kwargs) -> Dict[str, torch.nn.Module]:
+        if self.tokenizer_id is not None:
+            tokenizer = AutoTokenizer.from_pretrained(
+                self.tokenizer_id, revision=self.revision, cache_dir=self.cache_dir
+            )
+        else:
+            tokenizer = T5Tokenizer.from_pretrained(
+                self.pretrained_model_name_or_path,
+                subfolder="tokenizer",
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+
+        if self.text_encoder_id is not None:
+            text_encoder = AutoModel.from_pretrained(
+                self.text_encoder_id,
+                torch_dtype=self.text_encoder_dtype,
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+        else:
+            text_encoder = T5EncoderModel.from_pretrained(
+                self.pretrained_model_name_or_path,
+                subfolder="text_encoder",
+                torch_dtype=self.text_encoder_dtype,
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+
+        return {"tokenizer": tokenizer, "text_encoder": text_encoder}
+
+    def load_latent_models(self, *args, **kwargs) -> Dict[str, torch.nn.Module]:
+        if self.vae_id is not None:
+            vae = AutoencoderKLLTXVideo.from_pretrained(
+                self.vae_id,
+                torch_dtype=self.vae_dtype,
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+        else:
+            vae = AutoencoderKLLTXVideo.from_pretrained(
+                self.pretrained_model_name_or_path,
+                subfolder="vae",
+                torch_dtype=self.vae_dtype,
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+        return {"vae": vae}
+
+    def load_diffusion_models(self, *args, **kwargs) -> Dict[str, torch.nn.Module]:
+        if self.transformer_id is not None:
+            transformer = LTXVideoTransformer3DModel.from_pretrained(
+                self.transformer_id,
+                torch_dtype=self.transformer_dtype,
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+        else:
+            transformer = LTXVideoTransformer3DModel.from_pretrained(
+                self.pretrained_model_name_or_path,
+                subfolder="transformer",
+                torch_dtype=self.transformer_dtype,
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+
+        scheduler = FlowMatchEulerDiscreteScheduler()
+
+        return {"transformer": transformer, "scheduler": scheduler}
+
+    def load_pipeline(
+        self,
+        tokenizer: Optional[T5Tokenizer] = None,
+        text_encoder: Optional[T5EncoderModel] = None,
+        transformer: Optional[LTXVideoTransformer3DModel] = None,
+        vae: Optional[AutoencoderKLLTXVideo] = None,
+        scheduler: Optional[FlowMatchEulerDiscreteScheduler] = None,
+        enable_slicing: bool = False,
+        enable_tiling: bool = False,
+        enable_model_cpu_offload: bool = False,
+        training: bool = False,
+        device: Optional[torch.device] = None,
+        *args,
+        **kwargs,
+    ) -> LTXPipeline:
+        components = {
+            "tokenizer": tokenizer,
+            "text_encoder": text_encoder,
+            "transformer": transformer,
+            "vae": vae,
+            "scheduler": scheduler,
+        }
+        components = get_non_null_items(components)
+
+        pipe = LTXPipeline.from_pretrained(
+            self.pretrained_model_name_or_path, **components, revision=self.revision, cache_dir=self.cache_dir
+        )
+        pipe.text_encoder.to(self.text_encoder_dtype)
+        pipe.vae.to(self.vae_dtype)
+
+        if not training:
+            pipe.transformer.to(self.transformer_dtype)
+
+        if enable_slicing:
+            pipe.vae.enable_slicing()
+        if enable_tiling:
+            pipe.vae.enable_tiling()
+        if enable_model_cpu_offload:
+            pipe.enable_model_cpu_offload()
+        else:
+            pipe.to(device)
+
+        return pipe
+
+    def collate_fn(self, batch: List[List[Dict[str, torch.Tensor]]]) -> Dict[str, torch.Tensor]:
+        if "image" in batch[0][0]:
+            image_or_video = torch.stack([x["image"] for x in batch[0]])
+        else:
+            image_or_video = torch.stack([x["video"] for x in batch[0]])
+        return {
+            "text": [x["prompt"] for x in batch[0]],
+            "image_or_video": image_or_video,
+        }
+
+    def prepare_conditions(
+        self,
+        text: str,
+        tokenizer: T5Tokenizer,
+        text_encoder: T5EncoderModel,
+        max_sequence_length: int = 128,
+        *args,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        conditions = {}
+        for condition in self.conditions:
+            result = self._prepare_condition(
+                condition,
+                text=text,
+                tokenizer=tokenizer,
+                text_encoder=text_encoder,
+                max_sequence_length=max_sequence_length,
+            )
+            conditions.update(result)
+        return conditions
+
+    def prepare_latents(
+        self,
+        vae: AutoencoderKLLTXVideo,
+        image_or_video: torch.Tensor,
+        generator: Optional[torch.Generator] = None,
+        precompute: bool = False,
+        *args,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        device = vae.device
+        dtype = vae.dtype
+
+        if image_or_video.ndim == 4:
+            image_or_video = image_or_video.unsqueeze(2)
+        assert image_or_video.ndim == 5, f"Expected 5D tensor, got {image_or_video.ndim}D tensor"
+
+        image_or_video = image_or_video.to(device=device, dtype=vae.dtype)
+        image_or_video = image_or_video.permute(0, 2, 1, 3, 4).contiguous()  # [B, C, F, H, W] -> [B, F, C, H, W]
+
+        if not precompute:
+            patch_size = self.transformer_config.patch_size
+            patch_size_t = self.transformer_config.patch_size_t
+            latents = vae.encode(image_or_video).latent_dist.sample(generator=generator)
+            latents = latents.to(dtype=dtype)
+            _, _, num_frames, height, width = latents.shape
+            latents = self._normalize_latents(latents, vae.latents_mean, vae.latents_std)
+            latents = self._pack_latents(latents, patch_size, patch_size_t)
+
+            return {"latents": latents, "num_frames": num_frames, "height": height, "width": width}
+        else:
+            if vae.use_slicing and image_or_video.shape[0] > 1:
+                encoded_slices = [vae._encode(x_slice) for x_slice in image_or_video.split(1)]
+                h = torch.cat(encoded_slices)
+            else:
+                h = vae._encode(image_or_video)
+            _, _, num_frames, height, width = h.shape
+
+            # TODO(aryan): This is very stupid that we might possibly be storing the latents_mean and latents_std in every file
+            # if precomputation is enabled. We should probably have a single file where re-usable properties like this are stored
+            # so as to reduce the disk memory requirements of the precomputed files.
+            return {
+                "latents": h,
+                "num_frames": num_frames,
+                "height": height,
+                "width": width,
+                "latents_mean": vae.latents_mean,
+                "latents_std": vae.latents_std,
+            }
+
+    def postprocess_precomputed_conditions(
+        self,
+        condition_model_conditions: Dict[str, torch.Tensor],
+        latent_model_conditions: Dict[str, torch.Tensor],
+        *args,
+        **kwargs,
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+        latents = latent_model_conditions["latents"]
+        latents_mean = latent_model_conditions["latents_mean"]
+        latents_std = latent_model_conditions["latents_std"]
+
+        patch_size = self.transformer_config.patch_size
+        patch_size_t = self.transformer_config.patch_size_t
+        latents = self._normalize_latents(latents, latents_mean, latents_std)
+        latents = self._pack_latents(latents, patch_size, patch_size_t)
+
+        latent_model_conditions["latents"] = latents
+        return condition_model_conditions, latent_model_conditions
+
+    def forward(
+        self,
+        transformer: LTXVideoTransformer3DModel,
+        condition_model_conditions: Dict[str, torch.Tensor],
+        latent_model_conditions: Dict[str, torch.Tensor],
+        sigmas: torch.Tensor,
+        generator: Optional[torch.Generator] = None,
+        *args,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        latents = latent_model_conditions.pop("latents")
+        noise = torch.zeros_like(latents).normal_(generator=generator)
+        noisy_latents = FF.flow_match_xt(latents, noise, sigmas)
+        latent_model_conditions["hidden_states"] = noisy_latents.to(latents)
+
+        timesteps = (sigmas * 1000.0).long()
+
+        # TODO(aryan): make this configurable
+        frame_rate = 25
+        temporal_compression_ratio = 8
+        vae_spatial_compression_ratio = 32
+        latent_frame_rate = frame_rate / temporal_compression_ratio
+
+        rope_interpolation_scale = [
+            1 / latent_frame_rate,
+            vae_spatial_compression_ratio,
+            vae_spatial_compression_ratio,
+        ]
+
+        pred = transformer(
+            **latent_model_conditions,
+            **condition_model_conditions,
+            timestep=timesteps,
+            rope_interpolation_scale=rope_interpolation_scale,
+            return_dict=False,
+        )[0]
+        target = FF.flow_match_target(noise, latents)
+
+        return {
+            "pred": pred,
+            "target": target,
+        }
+
+    def validation(
+        self,
+        pipeline: LTXPipeline,
+        prompt: str,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_frames: Optional[int] = None,
+        frame_rate: int = 25,
+        num_videos_per_prompt: int = 1,
+        generator: Optional[torch.Generator] = None,
+        *args,
+        **kwargs,
+    ) -> List[Tuple[str, torch.Tensor]]:
+        generation_kwargs = {
+            "prompt": prompt,
+            "height": height,
+            "width": width,
+            "num_frames": num_frames,
+            "frame_rate": frame_rate,
+            "num_videos_per_prompt": num_videos_per_prompt,
+            "generator": generator,
+            "return_dict": True,
+            "output_type": "pil",
+        }
+        generation_kwargs = get_non_null_items(generation_kwargs)
+        video = pipeline(**generation_kwargs).frames[0]
+        return [("video", video)]
+
+    def _normalize_latents(
+        latents: torch.Tensor, latents_mean: torch.Tensor, latents_std: torch.Tensor, scaling_factor: float = 1.0
+    ) -> torch.Tensor:
+        # Normalize latents across the channel dimension [B, C, F, H, W]
+        latents_mean = latents_mean.view(1, -1, 1, 1, 1).to(latents.device, latents.dtype)
+        latents_std = latents_std.view(1, -1, 1, 1, 1).to(latents.device, latents.dtype)
+        latents = (latents - latents_mean) * scaling_factor / latents_std
+        return latents
+
+    def _pack_latents(latents: torch.Tensor, patch_size: int = 1, patch_size_t: int = 1) -> torch.Tensor:
+        # Unpacked latents of shape are [B, C, F, H, W] are patched into tokens of shape [B, C, F // p_t, p_t, H // p, p, W // p, p].
+        # The patch dimensions are then permuted and collapsed into the channel dimension of shape:
+        # [B, F // p_t * H // p * W // p, C * p_t * p * p] (an ndim=3 tensor).
+        # dim=0 is the batch size, dim=1 is the effective video sequence length, dim=2 is the effective number of input features
+        batch_size, num_channels, num_frames, height, width = latents.shape
+        post_patch_num_frames = num_frames // patch_size_t
+        post_patch_height = height // patch_size
+        post_patch_width = width // patch_size
+        latents = latents.reshape(
+            batch_size,
+            -1,
+            post_patch_num_frames,
+            patch_size_t,
+            post_patch_height,
+            patch_size,
+            post_patch_width,
+            patch_size,
+        )
+        latents = latents.permute(0, 2, 4, 6, 1, 3, 5, 7).flatten(4, 7).flatten(1, 3)
+        return latents

--- a/finetrainers/models/modeling_utils.py
+++ b/finetrainers/models/modeling_utils.py
@@ -1,0 +1,219 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+from diffusers import DiffusionPipeline
+from PIL.Image import Image
+
+from ..conditions import Condition, get_condition_parameters_from_dict
+from ..typing import SchedulerType, TokenizerType
+from ..utils import get_parameter_names, resolve_component_cls
+
+
+class ModelSpecification:
+    pipeline_cls = None
+
+    def __init__(
+        self,
+        pretrained_model_name_or_path: Optional[str] = None,
+        tokenizer_id: Optional[str] = None,
+        tokenizer_2_id: Optional[str] = None,
+        tokenizer_3_id: Optional[str] = None,
+        text_encoder_id: Optional[str] = None,
+        text_encoder_2_id: Optional[str] = None,
+        text_encoder_3_id: Optional[str] = None,
+        transformer_id: Optional[str] = None,
+        vae_id: Optional[str] = None,
+        text_encoder_dtype: torch.dtype = torch.bfloat16,
+        text_encoder_2_dtype: torch.dtype = torch.bfloat16,
+        text_encoder_3_dtype: torch.dtype = torch.bfloat16,
+        transformer_dtype: torch.dtype = torch.bfloat16,
+        vae_dtype: str = torch.bfloat16,
+        revision: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+    ) -> None:
+        if self.pipeline_cls is None:
+            raise ValueError(f"ModelSpecification {self.__class__.__name__} must define a pipeline_cls")
+
+        self.pretrained_model_name_or_path = pretrained_model_name_or_path
+        self.tokenizer_id = tokenizer_id
+        self.tokenizer_2_id = tokenizer_2_id
+        self.tokenizer_3_id = tokenizer_3_id
+        self.text_encoder_id = text_encoder_id
+        self.text_encoder_2_id = text_encoder_2_id
+        self.text_encoder_3_id = text_encoder_3_id
+        self.transformer_id = transformer_id
+        self.vae_id = vae_id
+        self.text_encoder_dtype = text_encoder_dtype
+        self.text_encoder_2_dtype = text_encoder_2_dtype
+        self.text_encoder_3_dtype = text_encoder_3_dtype
+        self.transformer_dtype = transformer_dtype
+        self.vae_dtype = vae_dtype
+        self.revision = revision
+        self.cache_dir = cache_dir
+
+        self.transformer_config: Dict[str, Any] = None
+        self.vae_config: Dict[str, Any] = None
+
+        self.conditions: Dict[str, Condition] = {}
+
+        self._load_configs()
+
+    def load_condition_models(self, *args, **kwargs) -> Dict[str, torch.nn.Module]:
+        raise NotImplementedError(
+            f"ModelSpecification::load_condition_models is not implemented for {self.__class__.__name__}"
+        )
+
+    def load_latent_models(self, *args, **kwargs) -> Dict[str, torch.nn.Module]:
+        raise NotImplementedError(
+            f"ModelSpecification::load_latent_models is not implemented for {self.__class__.__name__}"
+        )
+
+    def load_diffusion_models(self, *args, **kwargs) -> Dict[str, Union[torch.nn.Module]]:
+        raise NotImplementedError(
+            f"ModelSpecification::load_diffusion_models is not implemented for {self.__class__.__name__}"
+        )
+
+    def load_pipeline(
+        self,
+        tokenizer: Optional[TokenizerType] = None,
+        tokenizer_2: Optional[TokenizerType] = None,
+        tokenizer_3: Optional[TokenizerType] = None,
+        text_encoder: Optional[torch.nn.Module] = None,
+        text_encoder_2: Optional[torch.nn.Module] = None,
+        text_encoder_3: Optional[torch.nn.Module] = None,
+        transformer: Optional[torch.nn.Module] = None,
+        vae: Optional[torch.nn.Module] = None,
+        scheduler: Optional[SchedulerType] = None,
+        enable_slicing: bool = False,
+        enable_tiling: bool = False,
+        enable_model_cpu_offload: bool = False,
+        training: bool = False,
+        device: Optional[torch.device] = None,
+        *args,
+        **kwargs,
+    ) -> DiffusionPipeline:
+        raise NotImplementedError(
+            f"ModelSpecification::load_pipeline is not implemented for {self.__class__.__name__}"
+        )
+
+    def collate_fn(self, batch: List[List[Dict[str, torch.Tensor]]]) -> Dict[str, torch.Tensor]:
+        raise NotImplementedError(f"ModelSpecification::collate_fn is not implemented for {self.__class__.__name__}")
+
+    def prepare_conditions(
+        self,
+        tokenizer: Optional[TokenizerType] = None,
+        tokenizer_2: Optional[TokenizerType] = None,
+        tokenizer_3: Optional[TokenizerType] = None,
+        text_encoder: Optional[torch.nn.Module] = None,
+        text_encoder_2: Optional[torch.nn.Module] = None,
+        text_encoder_3: Optional[torch.nn.Module] = None,
+        max_sequence_length: Optional[int] = None,
+        *args,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        raise NotImplementedError(
+            f"ModelSpecification::prepare_conditions is not implemented for {self.__class__.__name__}"
+        )
+
+    def prepare_latents(
+        self,
+        vae: Optional[torch.nn.Module] = None,
+        image_or_video: Optional[torch.Tensor] = None,
+        generator: Optional[torch.Generator] = None,
+        precompute: bool = False,
+        *args,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        raise NotImplementedError(
+            f"ModelSpecification::prepare_latents is not implemented for {self.__class__.__name__}"
+        )
+
+    def postprocess_precomputed_conditions(
+        self,
+        condition_model_conditions: Dict[str, torch.Tensor],
+        latent_model_conditions: Dict[str, torch.Tensor],
+        *args,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        raise NotImplementedError(
+            f"ModelSpecification::postprocess_precomputed_latents is not implemented for {self.__class__.__name__}"
+        )
+
+    def forward(
+        self, transformer: torch.nn.Module, generator: Optional[torch.Generator] = None, *args, **kwargs
+    ) -> Dict[str, torch.Tensor]:
+        raise NotImplementedError(f"ModelSpecification::forward is not implemented for {self.__class__.__name__}")
+
+    def loss(self, *args, **kwargs) -> torch.Tensor:
+        raise NotImplementedError(f"ModelSpecification::loss is not implemented for {self.__class__.__name__}")
+
+    def validation(
+        self,
+        pipeline: DiffusionPipeline,
+        prompt: Optional[str] = None,
+        image: Optional[Image] = None,
+        video: Optional[List[Image]] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_images_per_prompt: int = 1,
+        num_videos_per_prompt: int = 1,
+        generator: Optional[torch.Generator] = None,
+    ) -> List[Tuple[str, Union[Image, List[Image]]]]:
+        raise NotImplementedError(f"ModelSpecification::validation is not implemented for {self.__class__.__name__}")
+
+    def _add_condition(self, name: str, condition: Condition) -> None:
+        self.conditions[name] = condition
+
+    def _remove_condition(self, name: str) -> None:
+        if name in self.conditions:
+            self.conditions.pop(name)
+
+    @staticmethod
+    def _prepare_condition(
+        condition: Condition,
+        *args,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        accepted_parameters = get_parameter_names(condition, "__call__")
+        condition_parameters = get_condition_parameters_from_dict(accepted_parameters, kwargs)
+        return condition(*args, **condition_parameters)
+
+    def _load_configs(self) -> None:
+        self._load_transformer_config()
+        self._load_vae_config()
+
+    def _load_transformer_config(self) -> None:
+        if self.transformer_id is not None:
+            self.transformer_config = resolve_component_cls(
+                self.transformer_id,
+                component_name="_class_name",
+                filename="config.json",
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+        else:
+            self.transformer_config = resolve_component_cls(
+                self.pretrained_model_name_or_path,
+                component_name="transformer",
+                filename="model_index.json",
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+
+    def _load_vae_config(self) -> None:
+        if self.vae_id is not None:
+            self.vae_config = resolve_component_cls(
+                self.vae_id,
+                component_name="_class_name",
+                filename="config.json",
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )
+        else:
+            self.vae_config = resolve_component_cls(
+                self.pretrained_model_name_or_path,
+                component_name="vae",
+                filename="model_index.json",
+                revision=self.revision,
+                cache_dir=self.cache_dir,
+            )

--- a/finetrainers/state.py
+++ b/finetrainers/state.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import torch
 from accelerate import Accelerator
 
@@ -16,6 +18,9 @@ class State:
     train_batch_size: int = None
     generator: torch.Generator = None
     num_update_steps_per_epoch: int = None
+
+    # Conditions
+    conditions: List[str] = []
 
     # Hub state
     repo_id: str = None

--- a/finetrainers/typing.py
+++ b/finetrainers/typing.py
@@ -1,0 +1,8 @@
+from typing import Union
+
+from diffusers import CogVideoXDDIMScheduler, FlowMatchEulerDiscreteScheduler
+from transformers import CLIPTokenizer, LlamaTokenizer, LlamaTokenizerFast, T5Tokenizer, T5TokenizerFast
+
+
+SchedulerType = Union[CogVideoXDDIMScheduler, FlowMatchEulerDiscreteScheduler]
+TokenizerType = Union[CLIPTokenizer, T5Tokenizer, T5TokenizerFast, LlamaTokenizer, LlamaTokenizerFast]

--- a/finetrainers/utils/__init__.py
+++ b/finetrainers/utils/__init__.py
@@ -1,3 +1,7 @@
+import inspect
+from typing import Any, Dict, Optional, Set
+
+from .data_utils import determine_batch_size, should_perform_precomputation
 from .diffusion_utils import (
     default_flow_shift,
     get_scheduler_alphas,
@@ -9,5 +13,16 @@ from .diffusion_utils import (
 )
 from .file_utils import delete_files, find_files
 from .memory_utils import bytes_to_gigabytes, free_memory, get_memory_statistics, make_contiguous
+from .model_utils import resolve_component_cls
 from .optimizer_utils import get_optimizer, gradient_norm, max_gradient
 from .torch_utils import unwrap_model
+
+
+def get_parameter_names(obj: Any, method_name: Optional[str] = None) -> Set[str]:
+    if method_name is not None:
+        obj = getattr(obj, method_name)
+    return {name for name, _ in inspect.signature(obj).parameters.items()}
+
+
+def get_non_null_items(d: Dict[str, Any]) -> Dict[str, Any]:
+    return {k: v for k, v in d.items() if v is not None}

--- a/finetrainers/utils/data_utils.py
+++ b/finetrainers/utils/data_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-from typing import Union
+from typing import Any, Union
 
+import torch
 from accelerate.logging import get_logger
 
 from ..constants import PRECOMPUTED_CONDITIONS_DIR_NAME, PRECOMPUTED_LATENTS_DIR_NAME
@@ -33,3 +34,18 @@ def should_perform_precomputation(precomputation_dir: Union[str, Path]) -> bool:
             return False
     logger.info("Precomputed data not found. Running precomputation.")
     return True
+
+
+def determine_batch_size(x: Any) -> int:
+    if isinstance(x, list):
+        return len(x)
+    if isinstance(x, torch.Tensor):
+        return x.size(0)
+    if isinstance(x, dict):
+        for key in x:
+            try:
+                return determine_batch_size(x[key])
+            except ValueError:
+                pass
+        return 1
+    raise ValueError("Could not determine batch size from input.")

--- a/finetrainers/utils/model_utils.py
+++ b/finetrainers/utils/model_utils.py
@@ -1,25 +1,32 @@
 import importlib
 import json
 import os
+from typing import Optional
 
 from huggingface_hub import hf_hub_download
 
 
-def resolve_vae_cls_from_ckpt_path(ckpt_path, **kwargs):
-    ckpt_path = str(ckpt_path)
-    if os.path.exists(str(ckpt_path)) and os.path.isdir(ckpt_path):
-        index_path = os.path.join(ckpt_path, "model_index.json")
+def resolve_component_cls(
+    pretrained_model_name_or_path: str,
+    component_name: str,
+    filename: str = "model_index.json",
+    revision: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+):
+    pretrained_model_name_or_path = str(pretrained_model_name_or_path)
+    if os.path.exists(str(pretrained_model_name_or_path)) and os.path.isdir(pretrained_model_name_or_path):
+        index_path = os.path.join(pretrained_model_name_or_path, filename)
     else:
-        revision = kwargs.get("revision", None)
-        cache_dir = kwargs.get("cache_dir", None)
         index_path = hf_hub_download(
-            repo_id=ckpt_path, filename="model_index.json", revision=revision, cache_dir=cache_dir
+            repo_id=pretrained_model_name_or_path, filename=filename, revision=revision, cache_dir=cache_dir
         )
 
     with open(index_path, "r") as f:
         model_index_dict = json.load(f)
-    assert "vae" in model_index_dict, "No VAE found in the modelx index dict."
 
-    vae_cls_config = model_index_dict["vae"]
-    library = importlib.import_module(vae_cls_config[0])
-    return getattr(library, vae_cls_config[1])
+    if component_name not in model_index_dict:
+        raise ValueError(f"No {component_name} found in the model index dict.")
+
+    cls_config = model_index_dict[component_name]
+    library = importlib.import_module(cls_config[0])
+    return getattr(library, cls_config[1])


### PR DESCRIPTION
- Standardizes the implementation required for supporting new models. This makes it easier to implement arbitrary models - even ones that don't depend on Diffusers
- Introduces "Conditions". The goal here is to support many different opt-in configurations that allow users to use various default conditioning methods via CLI args. Good for quick prototyping new ideas with models and helpful for upcoming Control LoRA support
- Allows usage of arbitrary text encoders, tokenizers, transformers outside of the `pretrained_model_name_or_path`
- Allows more flexibility in the calculation of prediction and targets, so that we don't have to workaround for models like Mochi

The goal here is to abstract out parts of the the trainer that _could possibly be_ model-specific. The overall training algorithm, distributed-ness, etc. will always still be handled by the trainer. There are still some kinks to work out but it is getting there slowly.

The next step, either in this PR or follow-up, or in near future depending on if I find the time this weekend, is to remove `accelerate` usage. After several hours of debugging and trying to make context parallism work with it, I can't get around NCCL hangs. Pure pytorch is just plain simpler to work with, and the way for using all the goodies of parallism-types to make training more scalable. Things may possibly break or be unstable for a bit, so planning on doing a v0.0.1 release before I merge this PR.

TODO:
- [ ] Convert CogVideoX
- [ ] Convert HunyuanVideo