### PR TITLE
calling save_model_card correctly

### DIFF
--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -875,13 +875,14 @@ class Trainer:
 
         if num_validation_samples == 0:
             logger.warning("No validation samples found. Skipping validation.")
-            if accelerator.is_main_process and self.args.push_to_hub:
-                save_model_card(
-                    args=self.args,
-                    repo_id=self.state.repo_id,
-                    videos=None,
-                    validation_prompts=None,
-                )
+            if accelerator.is_main_process:
+                if self.args.push_to_hub:
+                    save_model_card(
+                        args=self.args,
+                        repo_id=self.state.repo_id,
+                        videos=None,
+                        validation_prompts=None,
+                    )
             return
 
         self.transformer.eval()

--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -875,7 +875,7 @@ class Trainer:
 
         if num_validation_samples == 0:
             logger.warning("No validation samples found. Skipping validation.")
-            if accelerator.is_main_process:
+            if accelerator.is_main_process and self.args.push_to_hub:
                 save_model_card(
                     args=self.args,
                     repo_id=self.state.repo_id,

--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -876,7 +876,7 @@ class Trainer:
         if num_validation_samples == 0:
             logger.warning("No validation samples found. Skipping validation.")
             if accelerator.is_main_process:
-                if self.args.push_to_hub:
+                if self.args.push_to_hub and final_validation:
                     save_model_card(
                         args=self.args,
                         repo_id=self.state.repo_id,


### PR DESCRIPTION
Previously, when `num_validation_samples == 0` then `save_model_card` was called even if `self.args.push_to_hub` or `final_validation` was `False`.