### PR TITLE
Remove forceful precomputation behaviour; Improvements to data loading

### DIFF
--- a/docs/dataset/README.md
+++ b/docs/dataset/README.md
@@ -75,6 +75,8 @@ Any dataset loadable via the [🤗 HF datasets] directly should work (not widely
 
 Any dataset loadable via the [🤗 HF datasets] directly should work (not widely tested at the moment). We support the [`webdataset`](https://huggingface.co/docs/datasets/v3.3.2/en/image_dataset#webdataset) and [`webdataset`](https://huggingface.co/docs/datasets/v3.3.2/en/video_dataset#webdataset) formats.
 
+
+
 ## Validation Dataset Format
 
 Arguments related to validation are:
@@ -157,7 +159,8 @@ The following is a high-level overview of how datasets are loaded and preprocess
 
 ## Understanding how datasets are precomputed
 
-There are 3 arguments related to precomputation:
+There are 4 arguments related to precomputation:
+- `--enable_precomputation`: If set, precomputation will be enabled. The parameters that follow are only relevant if this flag is set. If this flag is not set, all models will be loaded in memory and training will take place without first precomputing embeddings.
 - `--precomputation_items`: The number of data points to precompute and store to disk at a time. This is useful for performing memory-efficient training without exhausting disk space by precomputing embeddings of the entire dataset(s) at once. We default to `512` data points, but configure this to a lower value for smaller datasets. As training progresses, the precomputed data will be read from disk and dispatched to data replicas. Once all precomputed data has been used, the next batch of data points will be precomputed and stored to disk in a rolling fashion.
 - `--precomputation_dir`: The directory where precomputed data will be stored. This is useful for resuming training from a checkpoint, as the precomputed data will be loaded from this directory. If this directory is not provided, the precomputed data will be stored in the `--output_dir/precomputed`.
 - `--precomputation_once`: If you're working with small datasets and want to precompute all embeddings at once, set this flag. This will allow you to train without having to compute embeddings every time the precomputed data is exhausted. Currently, `webdataset` format loading does not support this feature, and it is also disabled for `> 1024` data points due to hard coded logic (can be removed manually by users for now).

--- a/examples/training/sft/cogvideox/crush_smol_lora/train.sh
+++ b/examples/training/sft/cogvideox/crush_smol_lora/train.sh
@@ -49,6 +49,7 @@ model_cmd=(
 dataset_cmd=(
   --dataset_config $TRAINING_DATASET_CONFIG
   --dataset_shuffle_buffer_size 10
+  --enable_precomputation
   --precomputation_items 25
   --precomputation_once
 )

--- a/examples/training/sft/cogview4/raider_white_tarot/train.sh
+++ b/examples/training/sft/cogview4/raider_white_tarot/train.sh
@@ -49,6 +49,7 @@ model_cmd=(
 dataset_cmd=(
   --dataset_config $TRAINING_DATASET_CONFIG
   --dataset_shuffle_buffer_size 32
+  --enable_precomputation
   --precomputation_items 120
   --precomputation_once
 )

--- a/examples/training/sft/hunyuan_video/modal_labs_dissolve/train.sh
+++ b/examples/training/sft/hunyuan_video/modal_labs_dissolve/train.sh
@@ -45,6 +45,7 @@ model_cmd=(
 dataset_cmd=(
   --dataset_config $TRAINING_DATASET_CONFIG
   --dataset_shuffle_buffer_size 10
+  --enable_precomputation
   --precomputation_items 10
   --precomputation_once
 )

--- a/examples/training/sft/ltx_video/crush_smol_lora/train.sh
+++ b/examples/training/sft/ltx_video/crush_smol_lora/train.sh
@@ -49,6 +49,7 @@ model_cmd=(
 dataset_cmd=(
   --dataset_config $TRAINING_DATASET_CONFIG
   --dataset_shuffle_buffer_size 10
+  --enable_precomputation
   --precomputation_items 25
   --precomputation_once
 )

--- a/examples/training/sft/ltx_video/crush_smol_lora/train_multires.sh
+++ b/examples/training/sft/ltx_video/crush_smol_lora/train_multires.sh
@@ -54,6 +54,7 @@ model_cmd=(
 dataset_cmd=(
   --dataset_config $TRAINING_DATASET_CONFIG
   --dataset_shuffle_buffer_size 50
+  --enable_precomputation
   --precomputation_items 100
   --precomputation_once
 )

--- a/examples/training/sft/wan/3dgs_dissolve/train.sh
+++ b/examples/training/sft/wan/3dgs_dissolve/train.sh
@@ -49,6 +49,7 @@ model_cmd=(
 dataset_cmd=(
   --dataset_config $TRAINING_DATASET_CONFIG
   --dataset_shuffle_buffer_size 10
+  --enable_precomputation
   --precomputation_items 100
   --precomputation_once
 )

--- a/examples/training/sft/wan/crush_smol_lora/train.sh
+++ b/examples/training/sft/wan/crush_smol_lora/train.sh
@@ -49,6 +49,7 @@ model_cmd=(
 dataset_cmd=(
   --dataset_config $TRAINING_DATASET_CONFIG
   --dataset_shuffle_buffer_size 10
+  --enable_precomputation
   --precomputation_items 25
   --precomputation_once
 )

--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -316,6 +316,7 @@ class BaseArgs:
     # Dataset arguments
     dataset_config: str = None
     dataset_shuffle_buffer_size: int = 1
+    enable_precomputation: bool = False
     precomputation_items: int = 512
     precomputation_dir: Optional[str] = None
     precomputation_once: bool = False
@@ -420,6 +421,7 @@ class BaseArgs:
         dataset_arguments = {
             "dataset_config": self.dataset_config,
             "dataset_shuffle_buffer_size": self.dataset_shuffle_buffer_size,
+            "enable_precomputation": self.enable_precomputation,
             "precomputation_items": self.precomputation_items,
             "precomputation_dir": self.precomputation_dir,
             "precomputation_once": self.precomputation_once,
@@ -625,6 +627,7 @@ def _add_model_arguments(parser: argparse.ArgumentParser) -> None:
 def _add_dataset_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--dataset_config", type=str, required=True)
     parser.add_argument("--dataset_shuffle_buffer_size", type=int, default=1)
+    parser.add_argument("--enable_precomputation", action="store_true")
     parser.add_argument("--precomputation_items", type=int, default=512)
     parser.add_argument("--precomputation_dir", type=str, default=None)
     parser.add_argument("--precomputation_once", action="store_true")
@@ -761,6 +764,7 @@ def _map_to_args_type(args: Dict[str, Any]) -> BaseArgs:
     # Dataset arguments
     result_args.dataset_config = args.dataset_config
     result_args.dataset_shuffle_buffer_size = args.dataset_shuffle_buffer_size
+    result_args.enable_precomputation = args.enable_precomputation
     result_args.precomputation_items = args.precomputation_items
     result_args.precomputation_dir = args.precomputation_dir or os.path.join(args.output_dir, "precomputed")
     result_args.precomputation_once = args.precomputation_once

--- a/finetrainers/data/__init__.py
+++ b/finetrainers/data/__init__.py
@@ -14,6 +14,14 @@ from .dataset import (
     initialize_dataset,
     wrap_iterable_dataset_for_preprocessing,
 )
-from .precomputation import DistributedDataPreprocessor, PreprocessedDataIterable
+from .precomputation import (
+    InMemoryDataIterable,
+    InMemoryDistributedDataPreprocessor,
+    InMemoryOnceDataIterable,
+    PrecomputedDataIterable,
+    PrecomputedDistributedDataPreprocessor,
+    PrecomputedOnceDataIterable,
+    initialize_preprocessor,
+)
 from .sampler import ResolutionSampler
 from .utils import find_files

--- a/finetrainers/data/dataset.py
+++ b/finetrainers/data/dataset.py
@@ -758,11 +758,10 @@ def _initialize_hub_dataset(dataset_name: str, dataset_type: str, infinite: bool
     elif _has_data_file_caption_file_lists(repo_file_list, remote=True):
         return _initialize_data_file_caption_file_dataset_from_hub(dataset_name, dataset_type, infinite)
 
-    has_tar_files = any(file.endswith(".tar") for file in repo_file_list)
+    has_tar_files = any(file.endswith(".tar") or file.endswith(".parquet") for file in repo_file_list)
     if has_tar_files:
         return _initialize_webdataset(dataset_name, dataset_type, infinite)
 
-    # TODO(aryan): handle parquet
     # TODO(aryan): This should be improved
     caption_files = [pathlib.Path(file).name for file in repo_file_list if file.endswith(".txt")]
     if len(caption_files) < MAX_PRECOMPUTABLE_ITEMS_LIMIT:

--- a/finetrainers/data/precomputation.py
+++ b/finetrainers/data/precomputation.py
@@ -1,13 +1,132 @@
 import pathlib
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 import torch
 from tqdm.auto import tqdm
 
 from .. import utils
+from ..logging import get_logger
 
 
-class DistributedDataPreprocessor:
+logger = get_logger()
+
+
+def initialize_preprocessor(
+    rank: int,
+    num_items: int,
+    processor_fn: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]],
+    save_dir: Optional[str] = None,
+    enable_precomputation: bool = False,
+) -> Union["InMemoryDistributedDataPreprocessor", "PrecomputedDistributedDataPreprocessor"]:
+    if enable_precomputation:
+        return PrecomputedDistributedDataPreprocessor(rank, num_items, processor_fn, save_dir)
+    return InMemoryDistributedDataPreprocessor(rank, num_items, processor_fn)
+
+
+class DistributedDataProcessorMixin:
+    def consume(self, *args, **kwargs):
+        raise NotImplementedError("DistributedDataProcessorMixin::consume must be implemented by the subclass.")
+
+    def consume_once(self, *args, **kwargs):
+        raise NotImplementedError("DistributedDataProcessorMixin::consume_once must be implemented by the subclass.")
+
+    @property
+    def requires_data(self):
+        raise NotImplementedError("DistributedDataProcessorMixin::requires_data must be implemented by the subclass.")
+
+
+class InMemoryDistributedDataPreprocessor(DistributedDataProcessorMixin):
+    def __init__(
+        self, rank: int, num_items: int, processor_fn: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]]
+    ) -> None:
+        super().__init__()
+
+        self._rank = rank
+        self._num_items = num_items
+        self._processor_fn = processor_fn
+
+        self._cached_samples = []
+        self._buffer = InMemoryDataBuffer(num_items)
+        self._preprocessed_iterator: Union["InMemoryDataIterable", "InMemoryOnceDataIterable"] = None
+
+    def consume(
+        self,
+        data_type: str,
+        components: Dict[str, Any],
+        data_iterator,
+        generator: Optional[torch.Generator] = None,
+        cache_samples: bool = False,
+        use_cached_samples: bool = False,
+        drop_samples: bool = False,
+    ) -> Iterable[Dict[str, Any]]:
+        if data_type not in self._processor_fn.keys():
+            raise ValueError(f"Invalid data type: {data_type}. Supported types: {list(self._processor_fn.keys())}")
+        if cache_samples:
+            if use_cached_samples:
+                raise ValueError("Cannot cache and use cached samples at the same time.")
+            if drop_samples:
+                raise ValueError("Cannot cache and drop samples at the same time.")
+
+        for i in tqdm(range(self._num_items), desc=f"Rank {self._rank}", total=self._num_items):
+            if use_cached_samples:
+                item = self._cached_samples[i]
+            else:
+                item = next(data_iterator)
+                if cache_samples:
+                    self._cached_samples.append(item)
+            item = self._processor_fn[data_type](**item, **components, generator=generator)
+            self._buffer.add(data_type, item)
+
+        if drop_samples:
+            del self._cached_samples
+            self._cached_samples = []
+
+        self._preprocessed_iterator = InMemoryDataIterable(self._rank, data_type, self._buffer)
+        return iter(self._preprocessed_iterator)
+
+    def consume_once(
+        self,
+        data_type: str,
+        components: Dict[str, Any],
+        data_iterator,
+        generator: Optional[torch.Generator] = None,
+        cache_samples: bool = False,
+        use_cached_samples: bool = False,
+        drop_samples: bool = False,
+    ) -> Iterable[Dict[str, Any]]:
+        if data_type not in self._processor_fn.keys():
+            raise ValueError(f"Invalid data type: {data_type}. Supported types: {list(self._processor_fn.keys())}")
+        if cache_samples:
+            if use_cached_samples:
+                raise ValueError("Cannot cache and use cached samples at the same time.")
+            if drop_samples:
+                raise ValueError("Cannot cache and drop samples at the same time.")
+
+        for i in tqdm(range(self._num_items), desc=f"Rank {self._rank}", total=self._num_items):
+            if use_cached_samples:
+                item = self._cached_samples[i]
+            else:
+                item = next(data_iterator)
+                if cache_samples:
+                    self._cached_samples.append(item)
+            item = self._processor_fn[data_type](**item, **components, generator=generator)
+            self._buffer.add(data_type, item)
+
+        if drop_samples:
+            del self._cached_samples
+            self._cached_samples = []
+
+        self._preprocessed_iterator = InMemoryOnceDataIterable(self._rank, data_type, self._buffer)
+        return iter(self._preprocessed_iterator)
+
+    @property
+    def requires_data(self):
+        if self._preprocessed_iterator is None:
+            return True
+        return self._preprocessed_iterator.requires_data
+
+
+class PrecomputedDistributedDataPreprocessor(DistributedDataProcessorMixin):
     def __init__(
         self,
         rank: int,
@@ -15,13 +134,15 @@ class DistributedDataPreprocessor:
         processor_fn: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]],
         save_dir: str,
     ) -> None:
+        super().__init__()
+
         self._rank = rank
         self._num_items = num_items
         self._processor_fn = processor_fn
         self._save_dir = pathlib.Path(save_dir)
 
         self._cached_samples = []
-        self._preprocessed_iterator: "PreprocessedDataIterable" = None
+        self._preprocessed_iterator: Union["PrecomputedDataIterable", "PrecomputedOnceDataIterable"] = None
 
         self._save_dir.mkdir(parents=True, exist_ok=True)
 
@@ -59,9 +180,8 @@ class DistributedDataPreprocessor:
         if drop_samples:
             del self._cached_samples
             self._cached_samples = []
-            utils.free_memory()
 
-        self._preprocessed_iterator = PreprocessedDataIterable(self._rank, self._save_dir, data_type)
+        self._preprocessed_iterator = PrecomputedDataIterable(self._rank, self._save_dir, data_type)
         return iter(self._preprocessed_iterator)
 
     def consume_once(
@@ -95,9 +215,8 @@ class DistributedDataPreprocessor:
         if drop_samples:
             del self._cached_samples
             self._cached_samples = []
-            utils.free_memory()
 
-        self._preprocessed_iterator = PreprocessedOnceDataIterable(self._rank, self._save_dir, data_type)
+        self._preprocessed_iterator = PrecomputedOnceDataIterable(self._rank, self._save_dir, data_type)
         return iter(self._preprocessed_iterator)
 
     @property
@@ -107,7 +226,72 @@ class DistributedDataPreprocessor:
         return self._preprocessed_iterator.requires_data
 
 
-class PreprocessedDataIterable:
+class InMemoryDataIterable:
+    """
+    An iterator that loads data items from an in-memory buffer. Once all the data is consumed,
+    `requires_data` is set to True, indicating that the more data is required and the preprocessor's
+    consume method should be called again.
+    """
+
+    def __init__(self, rank: int, data_type: str, buffer: "InMemoryDataBuffer") -> None:
+        self._rank = rank
+        self._data_type = data_type
+        self._buffer = buffer
+
+        self._requires_data = False
+
+    def __iter__(self) -> Iterable[Dict[str, Any]]:
+        while length := self._buffer.get_length(self._data_type) > 0:
+            yield self._buffer.get(self._data_type)
+            if length == 1:
+                self._requires_data = True
+
+    def __len__(self) -> int:
+        return self._buffer.get_length(self._data_type)
+
+    @property
+    def requires_data(self):
+        return self._requires_data
+
+
+class InMemoryOnceDataIterable:
+    """
+    An iterator that loads data items from an in-memory buffer. This iterator will never set
+    `requires_data` to True, as it is assumed that all the data was configured to be preprocessed
+    by the user. The data will indefinitely be cycled from the buffer.
+    """
+
+    def __init__(self, rank: int, data_type: str, buffer: "InMemoryDataBuffer") -> None:
+        self._rank = rank
+        self._data_type = data_type
+        self._buffer = buffer
+
+        self._requires_data = False
+
+    def __iter__(self) -> Iterable[Dict[str, Any]]:
+        while True:
+            if self._buffer.get_length(self._data_type) == 0:
+                self._requires_data = True
+                break
+            item = self._buffer.get(self._data_type)
+            yield item
+            self._buffer.add(self._data_type, item)
+
+    def __len__(self) -> int:
+        return self._buffer.get_length(self._data_type)
+
+    @property
+    def requires_data(self):
+        return self._requires_data
+
+
+class PrecomputedDataIterable:
+    """
+    An iterator that loads preconfigured number of data items from disk. Once all the data is
+    loaded, `requires_data` is set to True, indicating that the more data is required and
+    the preprocessor's consume method should be called again.
+    """
+
     def __init__(self, rank: int, save_dir: str, data_type: str) -> None:
         self._rank = rank
         self._save_dir = pathlib.Path(save_dir)
@@ -130,7 +314,13 @@ class PreprocessedDataIterable:
         return self._requires_data
 
 
-class PreprocessedOnceDataIterable:
+class PrecomputedOnceDataIterable:
+    """
+    An infinite iterator that loads preprocessed data from disk. Once initialized, this iterator
+    will never set `requires_data` to True, as it is assumed that all the data was configured to
+    be preprocessed by the user.
+    """
+
     def __init__(self, rank: int, save_dir: str, data_type: str) -> None:
         self._rank = rank
         self._save_dir = pathlib.Path(save_dir)
@@ -151,6 +341,31 @@ class PreprocessedOnceDataIterable:
     @property
     def requires_data(self):
         return self._requires_data
+
+
+class InMemoryDataBuffer:
+    def __init__(self, max_limit: int = -1) -> None:
+        self.max_limit = max_limit
+        self.buffer: Dict[str, List[str]] = {}
+
+    def add(self, data_type: str, item: Dict[str, Any]) -> None:
+        if data_type not in self.buffer:
+            self.buffer[data_type] = []
+        if self.max_limit != -1 and len(self.buffer[data_type]) >= self.max_limit:
+            logger.log_freq(
+                "WARN",
+                "IN_MEMORY_DATA_BUFFER_FULL",
+                "Buffer is full. Dropping the oldest item. This message will be logged every 64th time this happens.",
+                64,
+            )
+            self.buffer[data_type].pop(0)
+        self.buffer[data_type].append(item)
+
+    def get(self, data_type: str) -> Dict[str, Any]:
+        return self.buffer[data_type].pop(0)
+
+    def get_length(self, data_type: str) -> int:
+        return len(self.buffer[data_type])
 
 
 def _save_item(rank: int, index: int, item: Dict[str, Any], directory: pathlib.Path, data_type: str) -> None:

--- a/finetrainers/trainer/sft_trainer/trainer.py
+++ b/finetrainers/trainer/sft_trainer/trainer.py
@@ -73,6 +73,7 @@ class SFTTrainer:
         patches.perform_patches_for_training(self.args, self.state.parallel_backend)
 
         self.model_specification = model_specification
+        self._are_condition_models_loaded = False
 
     def run(self) -> None:
         try:
@@ -370,9 +371,9 @@ class SFTTrainer:
         self.transformer.train()
         data_iterator = iter(self.dataloader)
 
-        preprocessor = data.DistributedDataPreprocessor(
+        preprocessor = data.initialize_preprocessor(
             rank=parallel_backend.rank,
-            num_items=self.args.precomputation_items,
+            num_items=self.args.precomputation_items if self.args.enable_precomputation else 1,
             processor_fn={
                 "condition": self.model_specification.prepare_conditions,
                 "latent": functools.partial(
@@ -380,6 +381,7 @@ class SFTTrainer:
                 ),
             },
             save_dir=self.args.precomputation_dir,
+            enable_precomputation=self.args.enable_precomputation,
         )
         precomputed_condition_iterator: Iterable[Dict[str, Any]] = None
         precomputed_latent_iterator: Iterable[Dict[str, Any]] = None
@@ -850,7 +852,6 @@ class SFTTrainer:
                 training=True,
             )
         else:
-            # TODO(aryan): this branch does not work yet, needs to be implemented
             self._delete_components()
 
             # Load the transformer weights from the final checkpoint if performing full-finetune
@@ -876,50 +877,80 @@ class SFTTrainer:
         self._move_components_to_device(list(components.values()))
         return pipeline
 
-    def _prepare_data(self, preprocessor: data.DistributedDataPreprocessor, data_iterator):
-        logger.info("Precomputed condition & latent data exhausted. Loading & preprocessing new data.")
-        if self.args.precomputation_once:
-            consume_fn = preprocessor.consume_once
+    def _prepare_data(self, preprocessor: data.PrecomputedDistributedDataPreprocessor, data_iterator):
+        if not self.args.enable_precomputation:
+            logger.info(
+                "Precomputation disabled. Loading in-memory data loaders. All components will be loaded on GPUs."
+            )
+
+            if not self._are_condition_models_loaded:
+                condition_components = self.model_specification.load_condition_models()
+                latent_components = self.model_specification.load_latent_models()
+                all_components = {**condition_components, **latent_components}
+                self._set_components(all_components)
+                self._move_components_to_device(list(all_components.values()))
+                utils._enable_vae_memory_optimizations(self.vae, self.args.enable_slicing, self.args.enable_tiling)
+
+            condition_iterator = preprocessor.consume(
+                "condition",
+                components=condition_components,
+                data_iterator=data_iterator,
+                generator=self.state.generator,
+                cache_samples=True,
+            )
+            latent_iterator = preprocessor.consume(
+                "latent",
+                components=latent_components,
+                data_iterator=data_iterator,
+                generator=self.state.generator,
+                use_cached_samples=True,
+                drop_samples=True,
+            )
+
+            self._are_condition_models_loaded = True
         else:
-            consume_fn = preprocessor.consume
+            logger.info("Precomputed condition & latent data exhausted. Loading & preprocessing new data.")
 
-        condition_components = self.model_specification.load_condition_models()
-        component_names = list(condition_components.keys())
-        component_modules = list(condition_components.values())
-        self._set_components(condition_components)
-        self._move_components_to_device(component_modules)
-        precomputed_condition_iterator = consume_fn(
-            "condition",
-            components=condition_components,
-            data_iterator=data_iterator,
-            generator=self.state.generator,
-            cache_samples=True,
-        )
-        self._delete_components(component_names)
-        del condition_components, component_names, component_modules
+            if self.args.precomputation_once:
+                consume_fn = preprocessor.consume_once
+            else:
+                consume_fn = preprocessor.consume
 
-        latent_components = self.model_specification.load_latent_models()
-        if self.vae is not None:
-            if self.args.enable_slicing:
-                self.vae.enable_slicing()
-            if self.args.enable_tiling:
-                self.vae.enable_tiling()
-        component_names = list(latent_components.keys())
-        component_modules = list(latent_components.values())
-        self._set_components(latent_components)
-        self._move_components_to_device(component_modules)
-        precomputed_latent_iterator = consume_fn(
-            "latent",
-            components=latent_components,
-            data_iterator=data_iterator,
-            generator=self.state.generator,
-            use_cached_samples=True,
-            drop_samples=True,
-        )
-        self._delete_components(component_names)
-        del latent_components, component_names, component_modules
+            # Prepare condition iterators
+            condition_components = self.model_specification.load_condition_models()
+            component_names = list(condition_components.keys())
+            component_modules = list(condition_components.values())
+            self._set_components(condition_components)
+            self._move_components_to_device(component_modules)
+            condition_iterator = consume_fn(
+                "condition",
+                components=condition_components,
+                data_iterator=data_iterator,
+                generator=self.state.generator,
+                cache_samples=True,
+            )
+            self._delete_components(component_names)
+            del condition_components, component_names, component_modules
 
-        return precomputed_condition_iterator, precomputed_latent_iterator
+            # Prepare latent iterators
+            latent_components = self.model_specification.load_latent_models()
+            utils._enable_vae_memory_optimizations(self.vae, self.args.enable_slicing, self.args.enable_tiling)
+            component_names = list(latent_components.keys())
+            component_modules = list(latent_components.values())
+            self._set_components(latent_components)
+            self._move_components_to_device(component_modules)
+            latent_iterator = consume_fn(
+                "latent",
+                components=latent_components,
+                data_iterator=data_iterator,
+                generator=self.state.generator,
+                use_cached_samples=True,
+                drop_samples=True,
+            )
+            self._delete_components(component_names)
+            del latent_components, component_names, component_modules
+
+        return condition_iterator, latent_iterator
 
     def _get_training_info(self) -> Dict[str, Any]:
         info = self.args.to_dict()

--- a/finetrainers/utils/__init__.py
+++ b/finetrainers/utils/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from .activation_checkpoint import apply_activation_checkpointing
 from .data import determine_batch_size, should_perform_precomputation
 from .diffusion import (
+    _enable_vae_memory_optimizations,
     default_flow_shift,
     get_scheduler_alphas,
     get_scheduler_sigmas,

--- a/finetrainers/utils/diffusion.py
+++ b/finetrainers/utils/diffusion.py
@@ -143,3 +143,10 @@ def prepare_target(
         raise ValueError(f"Unsupported scheduler type {type(scheduler)}")
 
     return target
+
+
+def _enable_vae_memory_optimizations(vae, enable_slicing: bool = False, enable_tiling: bool = False):
+    if hasattr(vae, "enable_slicing") and enable_slicing:
+        vae.enable_slicing()
+    if hasattr(vae, "enable_tiling") and enable_tiling:
+        vae.enable_tiling()

--- a/tests/data/test_precomputation.py
+++ b/tests/data/test_precomputation.py
@@ -1,0 +1,177 @@
+import tempfile
+import unittest
+
+from finetrainers.data import (
+    InMemoryDistributedDataPreprocessor,
+    PrecomputedDistributedDataPreprocessor,
+    VideoCaptionFilePairDataset,
+    initialize_preprocessor,
+    wrap_iterable_dataset_for_preprocessing,
+)
+from finetrainers.utils import find_files
+
+from .utils import create_dummy_directory_structure
+
+
+class PreprocessorFastTests(unittest.TestCase):
+    def setUp(self):
+        self.rank = 0
+        self.num_items = 3
+        self.processor_fn = {
+            "latent": self._latent_processor_fn,
+            "condition": self._condition_processor_fn,
+        }
+        self.save_dir = tempfile.TemporaryDirectory()
+
+        directory_structure = [
+            "0.mp4",
+            "1.mp4",
+            "2.mp4",
+            "0.txt",
+            "1.txt",
+            "2.txt",
+        ]
+        create_dummy_directory_structure(
+            directory_structure, self.save_dir, self.num_items, "a cat ruling the world", "mp4"
+        )
+
+        dataset = VideoCaptionFilePairDataset(self.save_dir.name, infinite=True)
+        dataset = wrap_iterable_dataset_for_preprocessing(
+            dataset,
+            dataset_type="video",
+            config={
+                "video_resolution_buckets": [[2, 32, 32]],
+                "reshape_mode": "bicubic",
+            },
+        )
+        self.dataset = dataset
+
+    def tearDown(self):
+        self.save_dir.cleanup()
+
+    @staticmethod
+    def _latent_processor_fn(**data):
+        video = data["video"]
+        video = video[:, :, :16, :16]
+        data["video"] = video
+        return data
+
+    @staticmethod
+    def _condition_processor_fn(**data):
+        caption = data["caption"]
+        caption = caption + " surrounded by mystical aura"
+        data["caption"] = caption
+        return data
+
+    def test_initialize_preprocessor(self):
+        preprocessor = initialize_preprocessor(
+            self.rank, self.num_items, self.processor_fn, self.save_dir.name, enable_precomputation=False
+        )
+        self.assertIsInstance(preprocessor, InMemoryDistributedDataPreprocessor)
+
+        preprocessor = initialize_preprocessor(
+            self.rank, self.num_items, self.processor_fn, self.save_dir.name, enable_precomputation=True
+        )
+        self.assertIsInstance(preprocessor, PrecomputedDistributedDataPreprocessor)
+
+    def test_in_memory_preprocessor_consume(self):
+        data_iterator = iter(self.dataset)
+        preprocessor = initialize_preprocessor(
+            self.rank, self.num_items, self.processor_fn, self.save_dir.name, enable_precomputation=False
+        )
+
+        condition_iterator = preprocessor.consume(
+            "condition", components={}, data_iterator=data_iterator, cache_samples=True
+        )
+        latent_iterator = preprocessor.consume(
+            "latent", components={}, data_iterator=data_iterator, use_cached_samples=True, drop_samples=True
+        )
+
+        self.assertFalse(preprocessor.requires_data)
+        for _ in range(self.num_items):
+            condition_item = next(condition_iterator)
+            latent_item = next(latent_iterator)
+            self.assertIn("caption", condition_item)
+            self.assertIn("video", latent_item)
+            self.assertEqual(condition_item["caption"], "a cat ruling the world surrounded by mystical aura")
+            self.assertEqual(latent_item["video"].shape[-2:], (16, 16))
+        self.assertTrue(preprocessor.requires_data)
+
+    def test_in_memory_preprocessor_consume_once(self):
+        data_iterator = iter(self.dataset)
+        preprocessor = initialize_preprocessor(
+            self.rank, self.num_items, self.processor_fn, self.save_dir.name, enable_precomputation=False
+        )
+
+        condition_iterator = preprocessor.consume_once(
+            "condition", components={}, data_iterator=data_iterator, cache_samples=True
+        )
+        latent_iterator = preprocessor.consume_once(
+            "latent", components={}, data_iterator=data_iterator, use_cached_samples=True, drop_samples=True
+        )
+
+        self.assertFalse(preprocessor.requires_data)
+        for _ in range(self.num_items):
+            condition_item = next(condition_iterator)
+            latent_item = next(latent_iterator)
+            self.assertIn("caption", condition_item)
+            self.assertIn("video", latent_item)
+            self.assertEqual(condition_item["caption"], "a cat ruling the world surrounded by mystical aura")
+            self.assertEqual(latent_item["video"].shape[-2:], (16, 16))
+        self.assertFalse(preprocessor.requires_data)
+
+    def test_precomputed_preprocessor_consume(self):
+        data_iterator = iter(self.dataset)
+        preprocessor = initialize_preprocessor(
+            self.rank, self.num_items, self.processor_fn, self.save_dir.name, enable_precomputation=True
+        )
+
+        condition_iterator = preprocessor.consume(
+            "condition", components={}, data_iterator=data_iterator, cache_samples=True
+        )
+        latent_iterator = preprocessor.consume(
+            "latent", components={}, data_iterator=data_iterator, use_cached_samples=True, drop_samples=True
+        )
+
+        condition_file_list = find_files(self.save_dir.name, "condition")
+        latent_file_list = find_files(self.save_dir.name, "latent")
+        self.assertEqual(len(condition_file_list), 3)
+        self.assertEqual(len(latent_file_list), 3)
+
+        self.assertFalse(preprocessor.requires_data)
+        for _ in range(self.num_items):
+            condition_item = next(condition_iterator)
+            latent_item = next(latent_iterator)
+            self.assertIn("caption", condition_item)
+            self.assertIn("video", latent_item)
+            self.assertEqual(condition_item["caption"], "a cat ruling the world surrounded by mystical aura")
+            self.assertEqual(latent_item["video"].shape[-2:], (16, 16))
+        self.assertTrue(preprocessor.requires_data)
+
+    def test_precomputed_preprocessor_consume_once(self):
+        data_iterator = iter(self.dataset)
+        preprocessor = initialize_preprocessor(
+            self.rank, self.num_items, self.processor_fn, self.save_dir.name, enable_precomputation=True
+        )
+
+        condition_iterator = preprocessor.consume_once(
+            "condition", components={}, data_iterator=data_iterator, cache_samples=True
+        )
+        latent_iterator = preprocessor.consume_once(
+            "latent", components={}, data_iterator=data_iterator, use_cached_samples=True, drop_samples=True
+        )
+
+        condition_file_list = find_files(self.save_dir.name, "condition")
+        latent_file_list = find_files(self.save_dir.name, "latent")
+        self.assertEqual(len(condition_file_list), 3)
+        self.assertEqual(len(latent_file_list), 3)
+
+        self.assertFalse(preprocessor.requires_data)
+        for _ in range(self.num_items):
+            condition_item = next(condition_iterator)
+            latent_item = next(latent_iterator)
+            self.assertIn("caption", condition_item)
+            self.assertIn("video", latent_item)
+            self.assertEqual(condition_item["caption"], "a cat ruling the world surrounded by mystical aura")
+            self.assertEqual(latent_item["video"].shape[-2:], (16, 16))
+        self.assertFalse(preprocessor.requires_data)

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -1,0 +1,53 @@
+import pathlib
+from typing import List
+
+from diffusers.utils import export_to_video
+from PIL import Image
+
+from finetrainers.data.dataset import COMMON_CAPTION_FILES, COMMON_IMAGE_FILES, COMMON_VIDEO_FILES  # noqa
+
+
+def create_dummy_directory_structure(
+    directory_structure: List[str], tmpdir, num_data_files: int, caption: str, metadata_extension: str
+):
+    for item in directory_structure:
+        # TODO(aryan): this should be improved
+        if item in COMMON_CAPTION_FILES:
+            data_file = pathlib.Path(tmpdir.name) / item
+            with open(data_file.as_posix(), "w") as f:
+                for _ in range(num_data_files):
+                    f.write(f"{caption}\n")
+        elif item in COMMON_IMAGE_FILES:
+            data_file = pathlib.Path(tmpdir.name) / item
+            with open(data_file.as_posix(), "w") as f:
+                for i in range(num_data_files):
+                    f.write(f"images/{i}.jpg\n")
+        elif item in COMMON_VIDEO_FILES:
+            data_file = pathlib.Path(tmpdir.name) / item
+            with open(data_file.as_posix(), "w") as f:
+                for i in range(num_data_files):
+                    f.write(f"videos/{i}.mp4\n")
+        elif item == "metadata.csv":
+            data_file = pathlib.Path(tmpdir.name) / item
+            with open(data_file.as_posix(), "w") as f:
+                f.write("file_name,caption\n")
+                for i in range(num_data_files):
+                    f.write(f"{i}.{metadata_extension},{caption}\n")
+        elif item == "metadata.jsonl":
+            data_file = pathlib.Path(tmpdir.name) / item
+            with open(data_file.as_posix(), "w") as f:
+                for i in range(num_data_files):
+                    f.write(f'{{"file_name": "{i}.{metadata_extension}", "caption": "{caption}"}}\n')
+        elif item.endswith(".txt"):
+            data_file = pathlib.Path(tmpdir.name) / item
+            with open(data_file.as_posix(), "w") as f:
+                f.write(caption)
+        elif item.endswith(".jpg") or item.endswith(".png"):
+            data_file = pathlib.Path(tmpdir.name) / item
+            Image.new("RGB", (64, 64)).save(data_file.as_posix())
+        elif item.endswith(".mp4"):
+            data_file = pathlib.Path(tmpdir.name) / item
+            export_to_video([Image.new("RGB", (64, 64))] * 4, data_file.as_posix(), fps=2)
+        else:
+            data_file = pathlib.Path(tmpdir.name, item)
+            data_file.mkdir(exist_ok=True, parents=True)

--- a/tests/trainer/test_sft_trainer.py
+++ b/tests/trainer/test_sft_trainer.py
@@ -9,6 +9,7 @@ import unittest
 
 import pytest
 from diffusers.utils import export_to_video
+from parameterized import parameterized
 from PIL import Image
 
 from finetrainers import BaseArgs, SFTTrainer, TrainingType, get_logger
@@ -34,10 +35,6 @@ def slow_down_tests():
     # Not doing so seems to randomly trigger some test failures, which wouldn't fail if run individually.
     # !!!Look into this in future!!!
     time.sleep(3)
-
-
-# TODO(aryan): Currently, there's no way to just run the precomputation tests vs just the non-precomputation tests. They
-# always run together. Split the tests and improve how this is done.
 
 
 class SFTTrainerFastTestsMixin:
@@ -116,69 +113,69 @@ class SFTTrainerLoRATestsMixin___PTD(SFTTrainerFastTestsMixin):
         args.target_modules = ["to_q", "to_k", "to_v", "to_out.0"]
         return args
 
-    def test___dp_degree_1___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 1
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_1___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_1___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 1
         args.batch_size = 2
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_2___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_2___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_2___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 2
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_shards_2___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_shards_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_shards = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_shards_2___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_shards_2___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_shards = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_2___dp_shards_2___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_2___dp_shards_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.dp_shards = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___tp_degree_2___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___tp_degree_2___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.tp_degree = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
 
@@ -189,69 +186,69 @@ class SFTTrainerFullFinetuneTestsMixin___PTD(SFTTrainerFastTestsMixin):
         args.training_type = TrainingType.FULL_FINETUNE
         return args
 
-    def test___dp_degree_1___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 1
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_1___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_1___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 1
         args.batch_size = 2
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_2___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_2___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_2___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 2
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_shards_2___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_shards_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_shards = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_shards_2___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_shards_2___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_shards = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___dp_degree_2___dp_shards_2___batch_size_1(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___dp_degree_2___dp_shards_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.dp_shards = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    def test___tp_degree_2___batch_size_2(self):
+    @parameterized("enable_precomputation", [False, True])
+    def test___tp_degree_2___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.tp_degree = 2
         args.batch_size = 1
-        self._test_training(args)
-        args.enable_precomputation = True
+        args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
 

--- a/tests/trainer/test_sft_trainer.py
+++ b/tests/trainer/test_sft_trainer.py
@@ -39,6 +39,7 @@ def slow_down_tests():
 # TODO(aryan): Currently, there's no way to just run the precomputation tests vs just the non-precomputation tests. They
 # always run together. Split the tests and improve how this is done.
 
+
 class SFTTrainerFastTestsMixin:
     model_specification_cls = None
     num_data_files = 4


### PR DESCRIPTION
Fixes #296 and #295.

Adds a `--enable_precomputation` flag. It is disable by default to that one can train normally without saving/loading from disk.

Adds some basic sanity-checking tests.

TODO:
- [x] update all existing examples to use `--enable_precomputation` since that was the default behaviour with them, and do a quick test
- [x] update docs

cc @tau-yihouxiang @dorpxam