### PR TITLE
Fix CogVideoX config error for invert_scale_latents

### DIFF
--- a/finetrainers/models/cogvideox/base_specification.py
+++ b/finetrainers/models/cogvideox/base_specification.py
@@ -299,7 +299,7 @@ class CogVideoXModelSpecification(ModelSpecification):
             latents = posterior.sample(generator=generator)
             del posterior
 
-        if not self.vae_config.invert_scale_latents:
+        if not getattr(self.vae_config, "invert_scale_latents", False):
             latents = latents * self.vae_config.scaling_factor
 
         if patch_size_t is not None:


### PR DESCRIPTION
CogVideoX-2B does not have this config attribute and will raise an error with previous check