### PR TITLE
Lower memory requirements on single GPU

### DIFF
--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -853,8 +853,9 @@ def _validate_dataset_args(args: BaseArgs):
 
 
 def _validate_validation_args(args: BaseArgs):
-    if args.world_size > 1 and args.enable_model_cpu_offload:
-        raise ValueError("Model CPU offload is not supported on multi-GPU at the moment.")
+    if args.enable_model_cpu_offload:
+        if any(x > 1 for x in [args.pp_degree, args.dp_degree, args.dp_shards, args.cp_degree, args.tp_degree]):
+            raise ValueError("Model CPU offload is not supported on multi-GPU at the moment.")
 
 
 def _display_helper_messages(args: argparse.Namespace):

--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -853,8 +853,8 @@ def _validate_dataset_args(args: BaseArgs):
 
 
 def _validate_validation_args(args: BaseArgs):
-    if args.dp_shards > 1 and args.enable_model_cpu_offload:
-        raise ValueError("Model CPU offload is not supported with FSDP at the moment.")
+    if args.world_size > 1 and args.enable_model_cpu_offload:
+        raise ValueError("Model CPU offload is not supported on multi-GPU at the moment.")
 
 
 def _display_helper_messages(args: argparse.Namespace):

--- a/finetrainers/trainer/sft_trainer/trainer.py
+++ b/finetrainers/trainer/sft_trainer/trainer.py
@@ -730,6 +730,7 @@ class SFTTrainer:
 
         parallel_backend.wait_for_everyone()
         if not final_validation:
+            self._move_components_to_device()
             self.transformer.train()
 
     def _evaluate(self) -> None:

--- a/finetrainers/trainer/sft_trainer/trainer.py
+++ b/finetrainers/trainer/sft_trainer/trainer.py
@@ -694,13 +694,14 @@ class SFTTrainer:
         # 3. Cleanup & log artifacts
         parallel_backend.wait_for_everyone()
 
-        # Remove all hooks that might have been added during pipeline initialization to the models
-        pipeline.remove_all_hooks()
-        del pipeline
-
-        utils.free_memory()
         memory_statistics = utils.get_memory_statistics()
         logger.info(f"Memory after validation end: {json.dumps(memory_statistics, indent=4)}")
+
+        # Remove all hooks that might have been added during pipeline initialization to the models
+        module_names = ["text_encoder", "text_encoder_2", "text_encoder_3", "vae"]
+        pipeline.remove_all_hooks()
+        del pipeline
+        self._delete_components(module_names)
         torch.cuda.reset_peak_memory_stats(parallel_backend.device)
 
         # Gather artifacts from all processes. We also need to flatten them since each process returns a list of artifacts.
@@ -836,7 +837,6 @@ class SFTTrainer:
         utils.synchronize_device()
 
     def _init_pipeline(self, final_validation: bool = False) -> DiffusionPipeline:
-        parallel_backend = self.state.parallel_backend
         module_names = ["text_encoder", "text_encoder_2", "text_encoder_3", "transformer", "vae"]
 
         if not final_validation:
@@ -871,7 +871,6 @@ class SFTTrainer:
                 enable_tiling=self.args.enable_tiling,
                 enable_model_cpu_offload=self.args.enable_model_cpu_offload,
                 training=False,
-                device=parallel_backend.device,
             )
 
             # Load the LoRA weights if performing LoRA finetuning
@@ -880,7 +879,8 @@ class SFTTrainer:
 
         components = {module_name: getattr(pipeline, module_name, None) for module_name in module_names}
         self._set_components(components)
-        self._move_components_to_device(list(components.values()))
+        if not self.args.enable_model_cpu_offload:
+            self._move_components_to_device(list(components.values()))
         return pipeline
 
     def _prepare_data(
@@ -923,17 +923,16 @@ class SFTTrainer:
         else:
             logger.info("Precomputed condition & latent data exhausted. Loading & preprocessing new data.")
 
-            # TODO(aryan): This needs to be revisited. For some reason, the tests did not detect that self.transformer
-            # had become None after this but should have been loaded back from the checkpoint.
-            # parallel_backend = self.state.parallel_backend
-            # train_state = self.state.train_state
-            # self.checkpointer.save(
-            #     train_state.step,
-            #     force=True,
-            #     _device=parallel_backend.device,
-            #     _is_main_process=parallel_backend.is_main_process,
-            # )
-            # self._delete_components(component_names=["transformer", "unet"])
+            parallel_backend = self.state.parallel_backend
+            train_state = self.state.train_state
+            self.checkpointer.save(
+                train_state.step,
+                force=True,
+                _device=parallel_backend.device,
+                _is_main_process=parallel_backend.is_main_process,
+            )
+            self._delete_components(component_names=["transformer"])
+            torch.cuda.reset_peak_memory_stats(parallel_backend.device)
 
             if self.args.precomputation_once:
                 consume_fn = preprocessor.consume_once
@@ -974,8 +973,9 @@ class SFTTrainer:
             self._delete_components(component_names)
             del latent_components, component_names, component_modules
 
-            # self.checkpointer.load()
-            # self.transformer = self.checkpointer.states["model"].model[0]
+            self.checkpointer.load()
+            # TODO(aryan): handle PP carefully when you get to it
+            self.transformer = self.checkpointer.states["model"].model[0]
 
         return condition_iterator, latent_iterator
 


### PR DESCRIPTION
Fixes https://github.com/a-r-r-o-w/finetrainers/issues/315#issuecomment-2715432823

Testing only with CogView4. It should have a similar effect on all other models due to same code paths.

-----

On multi-GPU, there should be no change based on the changes made.

-----

On single-GPU using no memory optimization flags (except the must-use defaults like `--gradient_checkpointing`:

| Phase                          | Value                  | Before  | This PR  |
|--------------------------------|------------------------|---------|----------|
| Memory before training start   | memory_allocated      | 11.973  | 11.973   |
|                                | memory_reserved       | 11.98   | 11.98    |
|                                | max_memory_allocated  | 11.973  | 11.973   |
|                                | max_memory_reserved   | 11.98   | 11.98    |
| Memory before validation start | memory_allocated      | 12.209  | 12.209   |
|                                | memory_reserved       | 13.922  | 12.934   |
|                                | max_memory_allocated  | 28.403  | 16.429   |
|                                | max_memory_reserved   | 28.842  | 16.863   |
| Memory after validation end    | memory_allocated      | 29.359  | 29.358   |
|                                | memory_reserved       | 29.383  | 35.117   |
|                                | max_memory_allocated  | 32.706  | 32.705   |
|                                | max_memory_reserved   | 35.111  | 35.117   |
| Memory before validation start | memory_allocated      | 29.361  | 12.211   |
|                                | memory_reserved       | 31.373  | 14.229   |
|                                | max_memory_allocated  | 30.934  | 13.784   |
|                                | max_memory_reserved   | 31.373  | 14.229   |

The peak memory usage is not reduced in this case. It makes sense because during validation, all components will be loaded onto the GPU. If offloading, such as enable_model_cpu_offload is enabled, we can reduce the peak!

-----

On single-GPU, using FP8 layerwise casting + model cpu offloading:

```
  --layerwise_upcasting_modules transformer
  --layerwise_upcasting_storage_dtype float8_e4m3fn
  --enable_model_cpu_offload
```

Fixes made:
- For single GPUs, move transformer to CPU when performing precomputation
- Deallocate conditioning and latent modules after validation
- If using enable_model_cpu_offload, don't move everything to GPU before the pipeline begins validation 

| Phase                         | Value                   | Before  | This PR  |
|-------------------------------|------------------------|---------|---------|
| Memory before training start  | memory_allocated       | 6.719   | 6.719   |
|                               | memory_reserved        | 6.732   | 6.732   |
|                               | max_memory_allocated   | 6.719   | 6.719   |
|                               | max_memory_reserved    | 6.732   | 6.732   |
| Memory before validation start | memory_allocated       | 6.956   | 6.956   |
|                               | memory_reserved        | 9.719   | 9.562   |
|                               | max_memory_allocated   | 23.149  | 16.429  |
|                               | max_memory_reserved    | 23.576  | 16.863  |
| Memory after validation end   | memory_allocated       | 0.236   | 0.238   |
|                               | memory_reserved        | 0.273   | 0.379   |
|                               | max_memory_allocated   | 23.149  | 16.646  |
|                               | max_memory_reserved    | 23.576  | 16.863  |
| Memory before validation start | memory_allocated       | 24.105  | 6.956   |
|                               | memory_reserved        | 26.006  | 9.65    |
|                               | max_memory_allocated   | 25.701  | 9.078   |
|                               | max_memory_reserved    | 26.006  | 9.65    |

-----

cc @neph1 Please give it a spin when you get time!