### PR TITLE
Add version guard for datasets 3.4.0; Fix argument documentation

### DIFF
--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -195,7 +195,7 @@ class BaseArgs:
     checkpointing_limit (`int`, defaults to `None`):
         Max number of checkpoints to store.
     resume_from_checkpoint (`str`, defaults to `None`):
-        an be an integer or the string `"latest"`. If an integer is provided, training will resume from that step if a
+        Can be an integer or the string `"latest"`. If an integer is provided, training will resume from that step if a
         checkpoint corresponding to it exists. If `"latest"` is provided, training will resume from the latest checkpoint
         in the `--output_dir`.
 

--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -195,8 +195,9 @@ class BaseArgs:
     checkpointing_limit (`int`, defaults to `None`):
         Max number of checkpoints to store.
     resume_from_checkpoint (`str`, defaults to `None`):
-        Whether training should be resumed from a previous checkpoint. Use a path saved by `checkpointing_steps`,
-        or `"latest"` to automatically select the last available checkpoint.
+        an be an integer or the string `"latest"`. If an integer is provided, training will resume from that step if a
+        checkpoint corresponding to it exists. If `"latest"` is provided, training will resume from the latest checkpoint
+        in the `--output_dir`.
 
     OPTIMIZER ARGUMENTS
     -------------------

--- a/finetrainers/data/dataset.py
+++ b/finetrainers/data/dataset.py
@@ -23,6 +23,7 @@ from ..logging import get_logger
 from ..utils.import_utils import is_datasets_version
 from . import utils
 
+
 import decord  # isort:skip
 
 decord.bridge.set_bridge("torch")
@@ -973,6 +974,7 @@ def _preprocess_image(image: PIL.Image.Image) -> torch.Tensor:
 
 
 if is_datasets_version("<", "3.4.0"):
+
     def _preprocess_video(video: decord.VideoReader) -> torch.Tensor:
         video = video.get_batch(list(range(len(video))))
         breakpoint()
@@ -983,7 +985,7 @@ if is_datasets_version("<", "3.4.0"):
 else:
     # Hardcode max frames for now. Ideally, we should allow user to set this and handle it in IterableDatasetPreprocessingWrapper
     MAX_FRAMES = 4096
-    
+
     def _preprocess_video(video: torchvision.io.video_reader.VideoReader) -> torch.Tensor:
         frames = []
         # Error driven data loading! torchvision does not expose length of video

--- a/finetrainers/data/dataset.py
+++ b/finetrainers/data/dataset.py
@@ -12,6 +12,7 @@ import numpy as np
 import PIL.Image
 import torch
 import torch.distributed.checkpoint.stateful
+import torchvision
 from diffusers.utils import load_image, load_video
 from huggingface_hub import list_repo_files, repo_exists, snapshot_download
 from tqdm.auto import tqdm
@@ -19,8 +20,8 @@ from tqdm.auto import tqdm
 from .. import constants
 from .. import functional as FF
 from ..logging import get_logger
+from ..utils.import_utils import is_datasets_version
 from . import utils
-
 
 import decord  # isort:skip
 
@@ -971,8 +972,26 @@ def _preprocess_image(image: PIL.Image.Image) -> torch.Tensor:
     return image
 
 
-def _preprocess_video(video: decord.VideoReader) -> torch.Tensor:
-    video = video.get_batch(list(range(len(video))))
-    video = video.permute(0, 3, 1, 2).contiguous()
-    video = video.float() / 127.5 - 1.0
-    return video
+if is_datasets_version("<", "3.4.0"):
+    def _preprocess_video(video: decord.VideoReader) -> torch.Tensor:
+        video = video.get_batch(list(range(len(video))))
+        breakpoint()
+        video = video.permute(0, 3, 1, 2).contiguous()
+        video = video.float() / 127.5 - 1.0
+        return video
+
+else:
+    # Hardcode max frames for now. Ideally, we should allow user to set this and handle it in IterableDatasetPreprocessingWrapper
+    MAX_FRAMES = 4096
+    
+    def _preprocess_video(video: torchvision.io.video_reader.VideoReader) -> torch.Tensor:
+        frames = []
+        # Error driven data loading! torchvision does not expose length of video
+        try:
+            for _ in range(MAX_FRAMES):
+                frames.append(next(video)["data"])
+        except StopIteration:
+            pass
+        video = torch.stack(frames)
+        video = video.float() / 127.5 - 1.0
+        return video

--- a/finetrainers/utils/import_utils.py
+++ b/finetrainers/utils/import_utils.py
@@ -60,7 +60,7 @@ def is_datasets_available():
 
 def is_datasets_version(operation: str, version: str):
     """
-    Compares the current bitsandbytes version to a given reference with an operation.
+    Compares the current datasets version to a given reference with an operation.
 
     Args:
         operation (`str`):

--- a/finetrainers/utils/import_utils.py
+++ b/finetrainers/utils/import_utils.py
@@ -1,8 +1,9 @@
 import importlib
-import importlib_metadata
 import operator as op
-from packaging.version import parse, Version
 from typing import Union
+
+import importlib_metadata
+from packaging.version import Version, parse
 
 from ..logging import get_logger
 
@@ -60,7 +61,7 @@ def is_datasets_available():
 def is_datasets_version(operation: str, version: str):
     """
     Compares the current bitsandbytes version to a given reference with an operation.
-    
+
     Args:
         operation (`str`):
             A string representation of an operator, such as `">"` or `"<="`

--- a/finetrainers/utils/import_utils.py
+++ b/finetrainers/utils/import_utils.py
@@ -1,11 +1,36 @@
 import importlib
-
 import importlib_metadata
+import operator as op
+from packaging.version import parse, Version
+from typing import Union
 
 from ..logging import get_logger
 
 
 logger = get_logger()
+
+STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
+
+
+# This function was copied from: https://github.com/huggingface/accelerate/blob/874c4967d94badd24f893064cc3bef45f57cadf7/src/accelerate/utils/versions.py#L319
+def compare_versions(library_or_version: Union[str, Version], operation: str, requirement_version: str):
+    """
+    Compares a library version to some requirement using a given operation.
+
+    Args:
+        library_or_version (`str` or `packaging.version.Version`):
+            A library name or a version to check.
+        operation (`str`):
+            A string representation of an operator, such as `">"` or `"<="`.
+        requirement_version (`str`):
+            The version to compare the library version against
+    """
+    if operation not in STR_OPERATION_TO_FUNC.keys():
+        raise ValueError(f"`operation` must be one of {list(STR_OPERATION_TO_FUNC.keys())}, received {operation}")
+    operation = STR_OPERATION_TO_FUNC[operation]
+    if isinstance(library_or_version, str):
+        library_or_version = parse(importlib_metadata.version(library_or_version))
+    return operation(library_or_version, parse(requirement_version))
 
 
 _bitsandbytes_available = importlib.util.find_spec("bitsandbytes") is not None
@@ -16,5 +41,32 @@ except importlib_metadata.PackageNotFoundError:
     _bitsandbytes_available = False
 
 
+_datasets_available = importlib.util.find_spec("datasets") is not None
+try:
+    _datasets_version = importlib_metadata.version("datasets")
+    logger.debug(f"Successfully imported datasets version {_datasets_version}")
+except importlib_metadata.PackageNotFoundError:
+    _datasets_available = False
+
+
 def is_bitsandbytes_available():
     return _bitsandbytes_available
+
+
+def is_datasets_available():
+    return _datasets_available
+
+
+def is_datasets_version(operation: str, version: str):
+    """
+    Compares the current bitsandbytes version to a given reference with an operation.
+    
+    Args:
+        operation (`str`):
+            A string representation of an operator, such as `">"` or `"<="`
+        version (`str`):
+            A version string
+    """
+    if not _datasets_available:
+        return False
+    return compare_versions(parse(_datasets_version), operation, version)


### PR DESCRIPTION
Fixes #329

20x faster data loading with https://github.com/huggingface/datasets/releases/tag/3.4.0 🥳 

cc @jbilcke-hf LMK if this works for you. I have not tested with a training run, but verified that the output shapes and values between the versions match