### PR TITLE
add __init__.py to sft_trainer/ to fix #335

### DIFF
--- a/finetrainers/trainer/sft_trainer/__init__.py
+++ b/finetrainers/trainer/sft_trainer/__init__.py
@@ -1,0 +1,1 @@
+from .trainer import SFTTrainer


### PR DESCRIPTION
This is a fix for #335

In order for the content of `/finetrainers/trainer/sft_trainer/` to be copied during `pip install`, I believe it is necessary to put a `__init__.py` inside the directory