### PR TITLE
Pytorch regional compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Please checkout [`docs/models`](./docs/models/) and [`examples/training`](./exam
 
 ## News
 
+- 🔥 **2025-04-08**: `torch.compile` support added!
 - 🔥 **2025-04-06**: Flux support added!
 - 🔥 **2025-03-07**: CogView4 support added!
 - 🔥 **2025-03-03**: Wan T2V support added!

--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -313,6 +313,7 @@ class BaseArgs:
         "^proj_out$",
         "norm",
     ]
+    compile_modules: List[str] = []
 
     # Dataset arguments
     dataset_config: str = None
@@ -416,6 +417,7 @@ class BaseArgs:
             "layerwise_upcasting_modules": self.layerwise_upcasting_modules,
             "layerwise_upcasting_storage_dtype": self.layerwise_upcasting_storage_dtype,
             "layerwise_upcasting_skip_modules_pattern": self.layerwise_upcasting_skip_modules_pattern,
+            "compile_modules": self.compile_modules,
         }
         model_arguments = get_non_null_items(model_arguments)
 
@@ -623,6 +625,7 @@ def _add_model_arguments(parser: argparse.ArgumentParser) -> None:
         default=["patch_embed", "pos_embed", "x_embedder", "context_embedder", "^proj_in$", "^proj_out$", "norm"],
         nargs="+",
     )
+    parser.add_argument("--compile_modules", type=str, default=[], nargs="+", choices=["transformer"])
 
 
 def _add_dataset_arguments(parser: argparse.ArgumentParser) -> None:
@@ -761,6 +764,7 @@ def _map_to_args_type(args: Dict[str, Any]) -> BaseArgs:
     result_args.layerwise_upcasting_modules = args.layerwise_upcasting_modules
     result_args.layerwise_upcasting_storage_dtype = _DTYPE_MAP[args.layerwise_upcasting_storage_dtype]
     result_args.layerwise_upcasting_skip_modules_pattern = args.layerwise_upcasting_skip_modules_pattern
+    result_args.compile_modules = args.compile_modules
 
     # Dataset arguments
     result_args.dataset_config = args.dataset_config

--- a/finetrainers/utils/__init__.py
+++ b/finetrainers/utils/__init__.py
@@ -19,10 +19,12 @@ from .memory import bytes_to_gigabytes, free_memory, get_memory_statistics, make
 from .model import resolve_component_cls
 from .torch import (
     align_device_and_dtype,
+    apply_compile,
     clip_grad_norm_,
     enable_determinism,
     expand_tensor_dims,
     get_device_info,
+    get_unwrapped_model_state_dict,
     set_requires_grad,
     synchronize_device,
 )

--- a/finetrainers/utils/_common.py
+++ b/finetrainers/utils/_common.py
@@ -3,4 +3,5 @@ DIFFUSERS_TRANSFORMER_BLOCK_NAMES = [
     "single_transformer_blocks",
     "temporal_transformer_blocks",
     "blocks",
+    "layers",
 ]

--- a/tests/trainer/test_sft_trainer.py
+++ b/tests/trainer/test_sft_trainer.py
@@ -140,12 +140,30 @@ class SFTTrainerLoRATestsMixin___Accelerate(SFTTrainerFastTestsMixin):
         args.layerwise_upcasting_modules = ["transformer"]
         self._test_training(args)
 
+    @parameterized.expand([(True,)])
+    def test___compile___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 1
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
+        self._test_training(args)
+
     @parameterized.expand([(False,), (True,)])
     def test___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 1
         args.enable_precomputation = enable_precomputation
+        self._test_training(args)
+
+    @parameterized.expand([(True,)])
+    def test___compile___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 2
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
         self._test_training(args)
 
 
@@ -164,12 +182,30 @@ class SFTTrainerFullFinetuneTestsMixin___Accelerate(SFTTrainerFastTestsMixin):
         args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
+    @parameterized.expand([(True,)])
+    def test___compile___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 1
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
+        self._test_training(args)
+
     @parameterized.expand([(False,), (True,)])
     def test___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 1
         args.enable_precomputation = enable_precomputation
+        self._test_training(args)
+
+    @parameterized.expand([(True,)])
+    def test___compile___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 2
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
         self._test_training(args)
 
 
@@ -261,6 +297,15 @@ class SFTTrainerLoRATestsMixin___PTD(SFTTrainerFastTestsMixin):
         args.layerwise_upcasting_modules = ["transformer"]
         self._test_training(args)
 
+    @parameterized.expand([(True,)])
+    def test___compile___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 1
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
+        self._test_training(args)
+
     @parameterized.expand([(False,), (True,)])
     def test___dp_degree_1___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
@@ -284,6 +329,15 @@ class SFTTrainerLoRATestsMixin___PTD(SFTTrainerFastTestsMixin):
         args.batch_size = 1
         args.enable_precomputation = enable_precomputation
         args.layerwise_upcasting_modules = ["transformer"]
+        self._test_training(args)
+
+    @parameterized.expand([(True,)])
+    def test___compile___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 2
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
         self._test_training(args)
 
     @parameterized.expand([(True,)])
@@ -344,6 +398,15 @@ class SFTTrainerFullFinetuneTestsMixin___PTD(SFTTrainerFastTestsMixin):
         self._test_training(args)
 
     @parameterized.expand([(True,)])
+    def test___compile___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 1
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
+        self._test_training(args)
+
+    @parameterized.expand([(True,)])
     def test___dp_degree_1___batch_size_2(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 1
@@ -357,6 +420,15 @@ class SFTTrainerFullFinetuneTestsMixin___PTD(SFTTrainerFastTestsMixin):
         args.dp_degree = 2
         args.batch_size = 1
         args.enable_precomputation = enable_precomputation
+        self._test_training(args)
+
+    @parameterized.expand([(True,)])
+    def test___compile___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
+        args = self.get_args()
+        args.dp_degree = 2
+        args.batch_size = 1
+        args.enable_precomputation = enable_precomputation
+        args.compile_modules = ["transformer"]
         self._test_training(args)
 
     @parameterized.expand([(True,)])

--- a/tests/trainer/test_sft_trainer.py
+++ b/tests/trainer/test_sft_trainer.py
@@ -140,30 +140,12 @@ class SFTTrainerLoRATestsMixin___Accelerate(SFTTrainerFastTestsMixin):
         args.layerwise_upcasting_modules = ["transformer"]
         self._test_training(args)
 
-    @parameterized.expand([(True,)])
-    def test___compile___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
-        args = self.get_args()
-        args.dp_degree = 1
-        args.batch_size = 1
-        args.enable_precomputation = enable_precomputation
-        args.compile_modules = ["transformer"]
-        self._test_training(args)
-
     @parameterized.expand([(False,), (True,)])
     def test___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 1
         args.enable_precomputation = enable_precomputation
-        self._test_training(args)
-
-    @parameterized.expand([(True,)])
-    def test___compile___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
-        args = self.get_args()
-        args.dp_degree = 2
-        args.batch_size = 1
-        args.enable_precomputation = enable_precomputation
-        args.compile_modules = ["transformer"]
         self._test_training(args)
 
 
@@ -182,30 +164,12 @@ class SFTTrainerFullFinetuneTestsMixin___Accelerate(SFTTrainerFastTestsMixin):
         args.enable_precomputation = enable_precomputation
         self._test_training(args)
 
-    @parameterized.expand([(True,)])
-    def test___compile___dp_degree_1___batch_size_1(self, enable_precomputation: bool):
-        args = self.get_args()
-        args.dp_degree = 1
-        args.batch_size = 1
-        args.enable_precomputation = enable_precomputation
-        args.compile_modules = ["transformer"]
-        self._test_training(args)
-
     @parameterized.expand([(False,), (True,)])
     def test___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
         args = self.get_args()
         args.dp_degree = 2
         args.batch_size = 1
         args.enable_precomputation = enable_precomputation
-        self._test_training(args)
-
-    @parameterized.expand([(True,)])
-    def test___compile___dp_degree_2___batch_size_1(self, enable_precomputation: bool):
-        args = self.get_args()
-        args.dp_degree = 2
-        args.batch_size = 1
-        args.enable_precomputation = enable_precomputation
-        args.compile_modules = ["transformer"]
         self._test_training(args)
 
 


### PR DESCRIPTION
Adds support for regional compilation on transformer blocks.

Training speedup with `torch.compile` can be enabled by settings `--compile_modules transformer` when launching training.

Accelerate hasn't been tested yet but most likely should work. As it hasn't been tested, unit tests are not yet added either.