### PR TITLE
[Doc] Fix a typo of `flux.md`

### DIFF
--- a/docs/models/flux.md
+++ b/docs/models/flux.md
@@ -1,4 +1,4 @@
-# CogView4
+# Flux
 
 ## Training
 


### PR DESCRIPTION
It seems that the title of `flux.md` is incorrect, so fix it.