### PR TITLE
[Fix] Raise ValueError proactively before some confusing errors occur due to wrong input image size

### DIFF
--- a/finetrainers/functional/image.py
+++ b/finetrainers/functional/image.py
@@ -8,9 +8,7 @@ def center_crop_image(image: torch.Tensor, size: Tuple[int, int]) -> torch.Tenso
     num_channels, height, width = image.shape
     crop_h, crop_w = size
     if height < crop_h or width < crop_w:
-        raise ValueError(
-            f"Image size {(height, width)} is smaller than the target size {size}."
-        )
+        raise ValueError(f"Image size {(height, width)} is smaller than the target size {size}.")
     top = (height - crop_h) // 2
     left = (width - crop_w) // 2
     return image[:, top : top + crop_h, left : left + crop_w]

--- a/finetrainers/functional/image.py
+++ b/finetrainers/functional/image.py
@@ -7,6 +7,10 @@ import torch.nn.functional as F
 def center_crop_image(image: torch.Tensor, size: Tuple[int, int]) -> torch.Tensor:
     num_channels, height, width = image.shape
     crop_h, crop_w = size
+    if height < crop_h or width < crop_w:
+        raise ValueError(
+            f"Image size {(height, width)} is smaller than the target size {size}."
+        )
     top = (height - crop_h) // 2
     left = (width - crop_w) // 2
     return image[:, top : top + crop_h, left : left + crop_w]

--- a/finetrainers/functional/video.py
+++ b/finetrainers/functional/video.py
@@ -8,9 +8,7 @@ def center_crop_video(video: torch.Tensor, size: Tuple[int, int]) -> torch.Tenso
     num_frames, num_channels, height, width = video.shape
     crop_h, crop_w = size
     if height < crop_h or width < crop_w:
-        raise ValueError(
-            f"Video size {(height, width)} is smaller than the target size {size}."
-        )
+        raise ValueError(f"Video size {(height, width)} is smaller than the target size {size}.")
     top = (height - crop_h) // 2
     left = (width - crop_w) // 2
     return video[:, :, top : top + crop_h, left : left + crop_w]

--- a/finetrainers/functional/video.py
+++ b/finetrainers/functional/video.py
@@ -7,6 +7,10 @@ import torch.nn.functional as F
 def center_crop_video(video: torch.Tensor, size: Tuple[int, int]) -> torch.Tensor:
     num_frames, num_channels, height, width = video.shape
     crop_h, crop_w = size
+    if height < crop_h or width < crop_w:
+        raise ValueError(
+            f"Video size {(height, width)} is smaller than the target size {size}."
+        )
     top = (height - crop_h) // 2
     left = (width - crop_w) // 2
     return video[:, :, top : top + crop_h, left : left + crop_w]


### PR DESCRIPTION
## Motivation

When I was finetuning a flux-dev model with my custom dataset, I got the following error:

```
Calculated padded input size per channel: (2 x 321). Kernel size: (3 x 3). Kernel size can't be greater than the actual input size
```

It was confusing, and it turned out that the image in my dataset was smaller than the crop size, which eventually led to the kernel error.

## Solution

I suggest we raise an exception when the input image/video is of the wrong size.

Moreover, I think we may add an option to keep only those images whose sizes are no smaller than the crop size and drop the others. (if needed, I can do that)