### PR TITLE
Improve webdataset caption loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,5 +172,6 @@ outputs*
 *.slurm
 .vscode/
 *dummy*
+*curated*
 
 !requirements.txt

--- a/finetrainers/data/dataset.py
+++ b/finetrainers/data/dataset.py
@@ -728,13 +728,16 @@ class IterableDatasetPreprocessingWrapper(
                             "after that."
                         )
                         logger.log_freq("WARNING", "BUCKET_TEMPORAL_SIZE_UNAVAILABLE", msg, frequency=128)
-                        sample["video"] = sample["video"][0]
+                        sample["video"] = sample["video"][:1]
 
+            caption = sample["caption"]
+            if caption.startswith("b'") and caption.endswith("'"):
+                caption = FF.convert_byte_str_to_str(caption)
             if self.remove_common_llm_caption_prefixes:
-                sample["caption"] = FF.remove_prefix(sample["caption"], constants.COMMON_LLM_START_PHRASES)
-
+                caption = FF.remove_prefix(caption, constants.COMMON_LLM_START_PHRASES)
             if self.id_token is not None:
-                sample["caption"] = f"{self.id_token} {sample['caption']}"
+                caption = f"{self.id_token} {caption}"
+            sample["caption"] = caption
 
             yield sample
 

--- a/finetrainers/functional/__init__.py
+++ b/finetrainers/functional/__init__.py
@@ -6,7 +6,7 @@ from .image import (
     resize_crop_image,
     resize_to_nearest_bucket_image,
 )
-from .text import dropout_caption, dropout_embeddings_to_zero, remove_prefix
+from .text import convert_byte_str_to_str, dropout_caption, dropout_embeddings_to_zero, remove_prefix
 from .video import (
     bicubic_resize_video,
     center_crop_video,

--- a/finetrainers/functional/text.py
+++ b/finetrainers/functional/text.py
@@ -4,6 +4,20 @@ from typing import List, Union
 import torch
 
 
+def convert_byte_str_to_str(s: str, encoding: str = "utf-8") -> str:
+    """
+    Extracts the actual string from a stringified bytes array (common in some webdatasets).
+
+    Example: "b'hello world'" -> "hello world"
+    """
+    try:
+        s = s[2:-1]
+        s = s.encode("utf-8").decode(encoding)
+    except (UnicodeDecodeError, UnicodeEncodeError, IndexError):
+        pass
+    return s
+
+
 def dropout_caption(caption: Union[str, List[str]], dropout_p: float = 0) -> Union[str, List[str]]:
     if random.random() >= dropout_p:
         return caption


### PR DESCRIPTION
Some webdatasets contain text encoded as byte arrays, but the `dataset.feature` for corresponding column set to string. This makes strings look like `"b'hello world'"` before feeding into text encoders and is problematic. This PR adds support for detecting such cases and converting the byte string to actual string.

```python
from finetrainers.data import initialize_dataset

ds = initialize_dataset("finetrainers/OpenVid-1k-split")
```