### PR TITLE
Fix #352: FSDP2 argument typo

### DIFF
--- a/finetrainers/trainer/sft_trainer/trainer.py
+++ b/finetrainers/trainer/sft_trainer/trainer.py
@@ -195,12 +195,12 @@ class SFTTrainer:
 
             parallel_backend.apply_fsdp2(
                 model=self.transformer,
-                dp_mesh=parallel_backend.get_mesh()[dp_mesh_names],
                 param_dtype=self.args.transformer_dtype,
                 reduce_dtype=torch.float32,
                 output_dtype=None,
                 pp_enabled=parallel_backend.pipeline_parallel_enabled,
                 cpu_offload=False,  # TODO(aryan): needs to be tested and allowed for enabling later
+                device_mesh=parallel_backend.get_mesh()[dp_mesh_names],
             )
         elif parallel_backend.data_replication_enabled:
             logger.info("Applying DDP to the model")


### PR DESCRIPTION
Fixes #352.

The mistake was probably made last minute due to some undo's during the major refactor for accelerate compatibility - #339 - because the test suite ran to completion.