### PR TITLE
HiDream ModelSpec

### DIFF
--- a/docs/args.md
+++ b/docs/args.md
@@ -46,12 +46,16 @@ tokenizer_2_id (`str`, defaults to `None`):
     Identifier for the second tokenizer model. This is useful when using a different tokenizer than the default from `pretrained_model_name_or_path`.
 tokenizer_3_id (`str`, defaults to `None`):
     Identifier for the third tokenizer model. This is useful when using a different tokenizer than the default from `pretrained_model_name_or_path`.
+tokenizer_4_id (`str`, defaults to `None`):
+    Identifier for the fourth tokenizer model. This is useful when using a different tokenizer than the default from `pretrained_model_name_or_path`.
 text_encoder_id (`str`, defaults to `None`):
     Identifier for the text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
 text_encoder_2_id (`str`, defaults to `None`):
     Identifier for the second text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
 text_encoder_3_id (`str`, defaults to `None`):
     Identifier for the third text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
+text_encoder_4_id (`str`, defaults to `None`):
+    Identifier for the fourth text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
 transformer_id (`str`, defaults to `None`):
     Identifier for the transformer model. This is useful when using a different transformer model than the default from `pretrained_model_name_or_path`.
 vae_id (`str`, defaults to `None`):

--- a/finetrainers/args.py
+++ b/finetrainers/args.py
@@ -60,12 +60,16 @@ class BaseArgs:
         Identifier for the second tokenizer model. This is useful when using a different tokenizer than the default from `pretrained_model_name_or_path`.
     tokenizer_3_id (`str`, defaults to `None`):
         Identifier for the third tokenizer model. This is useful when using a different tokenizer than the default from `pretrained_model_name_or_path`.
+    tokenizer_4_id (`str`, defaults to `None`):
+        Identifier for the fourth tokenizer model. This is useful when using a different tokenizer than the default from `pretrained_model_name_or_path`.
     text_encoder_id (`str`, defaults to `None`):
         Identifier for the text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
     text_encoder_2_id (`str`, defaults to `None`):
         Identifier for the second text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
     text_encoder_3_id (`str`, defaults to `None`):
         Identifier for the third text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
+    text_encoder_4_id (`str`, defaults to `None`):
+        Identifier for the fourth text encoder model. This is useful when using a different text encoder than the default from `pretrained_model_name_or_path`.
     transformer_id (`str`, defaults to `None`):
         Identifier for the transformer model. This is useful when using a different transformer model than the default from `pretrained_model_name_or_path`.
     vae_id (`str`, defaults to `None`):
@@ -76,6 +80,8 @@ class BaseArgs:
         Data type for the text encoder 2 when generating text embeddings.
     text_encoder_3_dtype (`torch.dtype`, defaults to `torch.bfloat16`):
         Data type for the text encoder 3 when generating text embeddings.
+    text_encoder_4_dtype (`torch.dtype`, defaults to `torch.bfloat16`):
+        Data type for the text encoder 4 when generating text embeddings.
     transformer_dtype (`torch.dtype`, defaults to `torch.bfloat16`):
         Data type for the transformer model.
     vae_dtype (`torch.dtype`, defaults to `torch.bfloat16`):
@@ -294,14 +300,17 @@ class BaseArgs:
     tokenizer_id: Optional[str] = None
     tokenizer_2_id: Optional[str] = None
     tokenizer_3_id: Optional[str] = None
+    tokenizer_4_id: Optional[str] = None
     text_encoder_id: Optional[str] = None
     text_encoder_2_id: Optional[str] = None
     text_encoder_3_id: Optional[str] = None
+    text_encoder_4_id: Optional[str] = None
     transformer_id: Optional[str] = None
     vae_id: Optional[str] = None
     text_encoder_dtype: torch.dtype = torch.bfloat16
     text_encoder_2_dtype: torch.dtype = torch.bfloat16
     text_encoder_3_dtype: torch.dtype = torch.bfloat16
+    text_encoder_4_dtype: torch.dtype = torch.bfloat16
     transformer_dtype: torch.dtype = torch.bfloat16
     vae_dtype: torch.dtype = torch.bfloat16
     layerwise_upcasting_modules: List[str] = []
@@ -410,14 +419,17 @@ class BaseArgs:
             "tokenizer_id": self.tokenizer_id,
             "tokenizer_2_id": self.tokenizer_2_id,
             "tokenizer_3_id": self.tokenizer_3_id,
+            "tokenizer_4_id": self.tokenizer_4_id,
             "text_encoder_id": self.text_encoder_id,
             "text_encoder_2_id": self.text_encoder_2_id,
             "text_encoder_3_id": self.text_encoder_3_id,
+            "text_encoder_4_id": self.text_encoder_4_id,
             "transformer_id": self.transformer_id,
             "vae_id": self.vae_id,
             "text_encoder_dtype": self.text_encoder_dtype,
             "text_encoder_2_dtype": self.text_encoder_2_dtype,
             "text_encoder_3_dtype": self.text_encoder_3_dtype,
+            "text_encoder_4_dtype": self.text_encoder_4_dtype,
             "transformer_dtype": self.transformer_dtype,
             "vae_dtype": self.vae_dtype,
             "layerwise_upcasting_modules": self.layerwise_upcasting_modules,
@@ -609,14 +621,17 @@ def _add_model_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--tokenizer_id", type=str, default=None)
     parser.add_argument("--tokenizer_2_id", type=str, default=None)
     parser.add_argument("--tokenizer_3_id", type=str, default=None)
+    parser.add_argument("--tokenizer_4_id", type=str, default=None)
     parser.add_argument("--text_encoder_id", type=str, default=None)
     parser.add_argument("--text_encoder_2_id", type=str, default=None)
     parser.add_argument("--text_encoder_3_id", type=str, default=None)
+    parser.add_argument("--text_encoder_4_id", type=str, default=None)
     parser.add_argument("--transformer_id", type=str, default=None)
     parser.add_argument("--vae_id", type=str, default=None)
     parser.add_argument("--text_encoder_dtype", type=str, default="bf16")
     parser.add_argument("--text_encoder_2_dtype", type=str, default="bf16")
     parser.add_argument("--text_encoder_3_dtype", type=str, default="bf16")
+    parser.add_argument("--text_encoder_4_dtype", type=str, default="bf16")
     parser.add_argument("--transformer_dtype", type=str, default="bf16")
     parser.add_argument("--vae_dtype", type=str, default="bf16")
     parser.add_argument("--layerwise_upcasting_modules", type=str, default=[], nargs="+", choices=["transformer"])
@@ -758,14 +773,17 @@ def _map_to_args_type(args: Dict[str, Any]) -> BaseArgs:
     result_args.tokenizer_id = args.tokenizer_id
     result_args.tokenizer_2_id = args.tokenizer_2_id
     result_args.tokenizer_3_id = args.tokenizer_3_id
+    result_args.tokenizer_4_id = args.tokenizer_4_id
     result_args.text_encoder_id = args.text_encoder_id
     result_args.text_encoder_2_id = args.text_encoder_2_id
     result_args.text_encoder_3_id = args.text_encoder_3_id
+    result_args.text_encoder_4_id = args.text_encoder_4_id
     result_args.transformer_id = args.transformer_id
     result_args.vae_id = args.vae_id
     result_args.text_encoder_dtype = _DTYPE_MAP[args.text_encoder_dtype]
     result_args.text_encoder_2_dtype = _DTYPE_MAP[args.text_encoder_2_dtype]
     result_args.text_encoder_3_dtype = _DTYPE_MAP[args.text_encoder_3_dtype]
+    result_args.text_encoder_4_dtype = _DTYPE_MAP[args.text_encoder_4_dtype]
     result_args.transformer_dtype = _DTYPE_MAP[args.transformer_dtype]
     result_args.vae_dtype = _DTYPE_MAP[args.vae_dtype]
     result_args.layerwise_upcasting_modules = args.layerwise_upcasting_modules

--- a/finetrainers/config.py
+++ b/finetrainers/config.py
@@ -5,6 +5,7 @@ from .models import ModelSpecification
 from .models.cogvideox import CogVideoXModelSpecification
 from .models.cogview4 import CogView4ControlModelSpecification, CogView4ModelSpecification
 from .models.flux import FluxModelSpecification
+from .models.hidream import HiDreamImageModelSpecification
 from .models.hunyuan_video import HunyuanVideoModelSpecification
 from .models.ltx_video import LTXVideoModelSpecification
 from .models.wan import WanControlModelSpecification, WanModelSpecification
@@ -14,6 +15,7 @@ class ModelType(str, Enum):
     COGVIDEOX = "cogvideox"
     COGVIEW4 = "cogview4"
     FLUX = "flux"
+    HIDREAM = "hidream"
     HUNYUAN_VIDEO = "hunyuan_video"
     LTX_VIDEO = "ltx_video"
     WAN = "wan"
@@ -45,6 +47,10 @@ SUPPORTED_MODEL_CONFIGS = {
     ModelType.FLUX: {
         TrainingType.LORA: FluxModelSpecification,
         TrainingType.FULL_FINETUNE: FluxModelSpecification,
+    },
+    ModelType.HIDREAM: {
+        TrainingType.LORA: HiDreamImageModelSpecification,
+        TrainingType.FULL_FINETUNE: HiDreamImageModelSpecification,
     },
     ModelType.HUNYUAN_VIDEO: {
         TrainingType.LORA: HunyuanVideoModelSpecification,

--- a/finetrainers/models/hidream/__init__.py
+++ b/finetrainers/models/hidream/__init__.py
@@ -1,0 +1,1 @@
+from .base_specification import HiDreamImageModelSpecification

--- a/finetrainers/models/hidream/base_specification.py
+++ b/finetrainers/models/hidream/base_specification.py
@@ -1,18 +1,34 @@
 import functools
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from accelerate import init_empty_weights
-from diffusers import AutoencoderKL, FlowMatchEulerDiscreteScheduler, FluxPipeline, FluxTransformer2DModel
+from diffusers import (
+    AutoencoderKL,
+    FlowMatchEulerDiscreteScheduler,
+    HiDreamImagePipeline,
+    HiDreamImageTransformer2DModel,
+)
 from diffusers.models.autoencoders.vae import DiagonalGaussianDistribution
-from transformers import AutoTokenizer, CLIPTextModel, CLIPTokenizer, T5EncoderModel
+from transformers import (
+    AutoTokenizer,
+    CLIPTextModelWithProjection,
+    CLIPTokenizer,
+    LlamaForCausalLM,
+    T5EncoderModel,
+    T5Tokenizer,
+)
 
 import finetrainers.functional as FF
 from finetrainers.data import ImageArtifact
 from finetrainers.logging import get_logger
 from finetrainers.models.modeling_utils import ModelSpecification
-from finetrainers.processors import CLIPTextModelPooledProcessor, ProcessorMixin, T5Processor
+from finetrainers.processors import (
+    CLIPTextModelWithProjectionPooledProcessor,
+    ProcessorMixin,
+    T5Processor,
+)
 from finetrainers.typing import ArtifactType, SchedulerType
 from finetrainers.utils import _enable_vae_memory_optimizations, get_non_null_items, safetensors_torch_save_function
 
@@ -20,9 +36,68 @@ from finetrainers.utils import _enable_vae_memory_optimizations, get_non_null_it
 logger = get_logger()
 
 
-class FluxLatentEncodeProcessor(ProcessorMixin):
+class HiDreamImageLlamaProcessor(ProcessorMixin):
     r"""
-    Processor to encode image/video into latents using the Flux VAE.
+    Processor for the Llama family of models specific to HiDream. This processor is used to encode text inputs
+    and return the embeddings and attention masks for the input text.
+
+    Args:
+        output_names (`List[str]`):
+            The names of the outputs that the processor should return. The first output is the embeddings of the input
+            text and the second output is the attention mask for the input text.
+    """
+
+    def __init__(
+        self, output_names: List[str], input_names: Optional[Dict[str, Any]] = None, use_attention_mask: bool = False
+    ):
+        super().__init__()
+
+        self.output_names = output_names
+        self.input_names = input_names
+        self.use_attention_mask = use_attention_mask
+
+        assert input_names is None or len(input_names) <= 4
+        assert len(self.output_names) == 1
+
+    def forward(
+        self,
+        tokenizer: AutoTokenizer,
+        text_encoder: LlamaForCausalLM,
+        caption: Union[str, List[str]],
+        max_sequence_length: int,
+    ) -> torch.Tensor:
+        if isinstance(caption, str):
+            caption = [caption]
+
+        device = text_encoder.device
+        dtype = text_encoder.dtype
+
+        text_inputs = tokenizer(
+            caption,
+            padding="max_length",
+            max_length=min(max_sequence_length, tokenizer.model_max_length),
+            truncation=True,
+            add_special_tokens=True,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids.to(device)
+        attention_mask = text_inputs.attention_mask.to(device)
+
+        outputs = text_encoder(
+            text_input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+            output_attentions=True,
+        )
+        prompt_embeds = outputs.hidden_states[1:]
+        prompt_embeds = torch.stack(prompt_embeds, dim=0).to(dtype=dtype)
+
+        return {self.output_names[0]: prompt_embeds}
+
+
+class HiDreamImageLatentEncodeProcessor(ProcessorMixin):
+    r"""
+    Processor to encode image/video into latents using the HiDream VAE.
 
     Args:
         output_names (`List[str]`):
@@ -68,17 +143,24 @@ class FluxLatentEncodeProcessor(ProcessorMixin):
         return {self.output_names[0]: latents}
 
 
-class FluxModelSpecification(ModelSpecification):
+class HiDreamImageModelSpecification(ModelSpecification):
     def __init__(
         self,
-        pretrained_model_name_or_path: str = "black-forest-labs/FLUX.1-dev",
+        pretrained_model_name_or_path: str = "HiDream-ai/HiDream-I1-Full",
         tokenizer_id: Optional[str] = None,
         tokenizer_2_id: Optional[str] = None,
+        tokenizer_3_id: Optional[str] = None,
+        tokenizer_4_id: Optional[str] = None,
         text_encoder_id: Optional[str] = None,
         text_encoder_2_id: Optional[str] = None,
+        text_encoder_3_id: Optional[str] = None,
+        text_encoder_4_id: Optional[str] = None,
         transformer_id: Optional[str] = None,
         vae_id: Optional[str] = None,
         text_encoder_dtype: torch.dtype = torch.bfloat16,
+        text_encoder_2_dtype: torch.dtype = torch.bfloat16,
+        text_encoder_3_dtype: torch.dtype = torch.bfloat16,
+        text_encoder_4_dtype: torch.dtype = torch.bfloat16,
         transformer_dtype: torch.dtype = torch.bfloat16,
         vae_dtype: torch.dtype = torch.bfloat16,
         revision: Optional[str] = None,
@@ -91,11 +173,18 @@ class FluxModelSpecification(ModelSpecification):
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             tokenizer_id=tokenizer_id,
             tokenizer_2_id=tokenizer_2_id,
+            tokenizer_3_id=tokenizer_3_id,
+            tokenizer_4_id=tokenizer_4_id,
             text_encoder_id=text_encoder_id,
             text_encoder_2_id=text_encoder_2_id,
+            text_encoder_3_id=text_encoder_3_id,
+            text_encoder_4_id=text_encoder_4_id,
             transformer_id=transformer_id,
             vae_id=vae_id,
             text_encoder_dtype=text_encoder_dtype,
+            text_encoder_2_dtype=text_encoder_2_dtype,
+            text_encoder_3_dtype=text_encoder_3_dtype,
+            text_encoder_4_dtype=text_encoder_4_dtype,
             transformer_dtype=transformer_dtype,
             vae_dtype=vae_dtype,
             revision=revision,
@@ -104,14 +193,23 @@ class FluxModelSpecification(ModelSpecification):
 
         if condition_model_processors is None:
             condition_model_processors = [
-                CLIPTextModelPooledProcessor(["pooled_projections"]),
-                T5Processor(
-                    ["encoder_hidden_states", "prompt_attention_mask"],
+                CLIPTextModelWithProjectionPooledProcessor(["pooled_prompt_embeds_1"]),
+                CLIPTextModelWithProjectionPooledProcessor(
+                    ["pooled_prompt_embeds_2"],
                     input_names={"tokenizer_2": "tokenizer", "text_encoder_2": "text_encoder"},
+                ),
+                T5Processor(
+                    ["encoder_hidden_states_t5", "__drop__"],
+                    input_names={"tokenizer_3": "tokenizer", "text_encoder_3": "text_encoder"},
+                    use_attention_mask=True,
+                ),
+                HiDreamImageLlamaProcessor(
+                    ["encoder_hidden_states_llama"],
+                    input_names={"tokenizer_4": "tokenizer", "text_encoder_4": "text_encoder"},
                 ),
             ]
         if latent_model_processors is None:
-            latent_model_processors = [FluxLatentEncodeProcessor(["latents"])]
+            latent_model_processors = [HiDreamImageLatentEncodeProcessor(["latents"])]
 
         self.condition_model_processors = condition_model_processors
         self.latent_model_processors = latent_model_processors
@@ -129,43 +227,85 @@ class FluxModelSpecification(ModelSpecification):
             tokenizer = CLIPTokenizer.from_pretrained(
                 self.pretrained_model_name_or_path, subfolder="tokenizer", **common_kwargs
             )
-
         if self.tokenizer_2_id is not None:
             tokenizer_2 = AutoTokenizer.from_pretrained(self.tokenizer_2_id, **common_kwargs)
         else:
-            tokenizer_2 = AutoTokenizer.from_pretrained(
+            tokenizer_2 = CLIPTokenizer.from_pretrained(
                 self.pretrained_model_name_or_path, subfolder="tokenizer_2", **common_kwargs
+            )
+        if self.tokenizer_3_id is not None:
+            tokenizer_3 = AutoTokenizer.from_pretrained(self.tokenizer_3_id, **common_kwargs)
+        else:
+            tokenizer_3 = T5Tokenizer.from_pretrained(
+                self.pretrained_model_name_or_path, subfolder="tokenizer_3", **common_kwargs
+            )
+        if self.tokenizer_4_id is not None:
+            tokenizer_4 = AutoTokenizer.from_pretrained(self.tokenizer_4_id, **common_kwargs)
+        else:
+            tokenizer_4 = AutoTokenizer.from_pretrained(
+                self.pretrained_model_name_or_path, subfolder="tokenizer_4", **common_kwargs
             )
 
         if self.text_encoder_id is not None:
-            text_encoder = CLIPTextModel.from_pretrained(
+            text_encoder = CLIPTextModelWithProjection.from_pretrained(
                 self.text_encoder_id, torch_dtype=self.text_encoder_dtype, **common_kwargs
             )
         else:
-            text_encoder = CLIPTextModel.from_pretrained(
+            text_encoder = CLIPTextModelWithProjection.from_pretrained(
                 self.pretrained_model_name_or_path,
                 subfolder="text_encoder",
                 torch_dtype=self.text_encoder_dtype,
                 **common_kwargs,
             )
-
         if self.text_encoder_2_id is not None:
-            text_encoder_2 = T5EncoderModel.from_pretrained(
+            text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(
                 self.text_encoder_2_id, torch_dtype=self.text_encoder_2_dtype, **common_kwargs
             )
         else:
-            text_encoder_2 = T5EncoderModel.from_pretrained(
+            text_encoder_2 = CLIPTextModelWithProjection.from_pretrained(
                 self.pretrained_model_name_or_path,
                 subfolder="text_encoder_2",
                 torch_dtype=self.text_encoder_2_dtype,
+                **common_kwargs,
+            )
+        if self.text_encoder_3_id is not None:
+            text_encoder_3 = T5EncoderModel.from_pretrained(
+                self.text_encoder_3_id, torch_dtype=self.text_encoder_3_dtype, **common_kwargs
+            )
+        else:
+            text_encoder_3 = T5EncoderModel.from_pretrained(
+                self.pretrained_model_name_or_path,
+                subfolder="text_encoder_3",
+                torch_dtype=self.text_encoder_3_dtype,
+                **common_kwargs,
+            )
+        if self.text_encoder_4_id is not None:
+            text_encoder_4 = LlamaForCausalLM.from_pretrained(
+                self.text_encoder_4_id,
+                torch_dtype=self.text_encoder_4_dtype,
+                output_hidden_states=True,
+                output_attentions=True,
+                **common_kwargs,
+            )
+        else:
+            text_encoder_4 = LlamaForCausalLM.from_pretrained(
+                self.pretrained_model_name_or_path,
+                subfolder="text_encoder_4",
+                torch_dtype=self.text_encoder_4_dtype,
+                output_hidden_states=True,
+                output_attentions=True,
                 **common_kwargs,
             )
 
         return {
             "tokenizer": tokenizer,
             "tokenizer_2": tokenizer_2,
+            "tokenizer_3": tokenizer_3,
+            "tokenizer_4": tokenizer_4,
             "text_encoder": text_encoder,
             "text_encoder_2": text_encoder_2,
+            "text_encoder_3": text_encoder_3,
+            "text_encoder_4": text_encoder_4,
         }
 
     def load_latent_models(self) -> Dict[str, torch.nn.Module]:
@@ -184,11 +324,11 @@ class FluxModelSpecification(ModelSpecification):
         common_kwargs = {"revision": self.revision, "cache_dir": self.cache_dir}
 
         if self.transformer_id is not None:
-            transformer = FluxTransformer2DModel.from_pretrained(
+            transformer = HiDreamImageTransformer2DModel.from_pretrained(
                 self.transformer_id, torch_dtype=self.transformer_dtype, **common_kwargs
             )
         else:
-            transformer = FluxTransformer2DModel.from_pretrained(
+            transformer = HiDreamImageTransformer2DModel.from_pretrained(
                 self.pretrained_model_name_or_path,
                 subfolder="transformer",
                 torch_dtype=self.transformer_dtype,
@@ -201,11 +341,15 @@ class FluxModelSpecification(ModelSpecification):
 
     def load_pipeline(
         self,
-        tokenizer: Optional[AutoTokenizer] = None,
+        tokenizer: Optional[CLIPTokenizer] = None,
         tokenizer_2: Optional[CLIPTokenizer] = None,
-        text_encoder: Optional[CLIPTextModel] = None,
-        text_encoder_2: Optional[T5EncoderModel] = None,
-        transformer: Optional[FluxTransformer2DModel] = None,
+        tokenizer_3: Optional[T5Tokenizer] = None,
+        tokenizer_4: Optional[AutoTokenizer] = None,
+        text_encoder: Optional[CLIPTextModelWithProjection] = None,
+        text_encoder_2: Optional[CLIPTextModelWithProjection] = None,
+        text_encoder_3: Optional[T5EncoderModel] = None,
+        text_encoder_4: Optional[LlamaForCausalLM] = None,
+        transformer: Optional[HiDreamImageTransformer2DModel] = None,
         vae: Optional[AutoencoderKL] = None,
         scheduler: Optional[FlowMatchEulerDiscreteScheduler] = None,
         enable_slicing: bool = False,
@@ -213,24 +357,27 @@ class FluxModelSpecification(ModelSpecification):
         enable_model_cpu_offload: bool = False,
         training: bool = False,
         **kwargs,
-    ) -> FluxPipeline:
+    ) -> HiDreamImagePipeline:
         components = {
             "tokenizer": tokenizer,
             "tokenizer_2": tokenizer_2,
+            "tokenizer_3": tokenizer_3,
+            "tokenizer_4": tokenizer_4,
             "text_encoder": text_encoder,
             "text_encoder_2": text_encoder_2,
+            "text_encoder_3": text_encoder_3,
+            "text_encoder_4": text_encoder_4,
             "transformer": transformer,
             "vae": vae,
-            # Load the scheduler based on Flux's config instead of using the default initialization being used for training
+            # Load the scheduler based on HiDream's config instead of using the default initialization being used for training
             # "scheduler": scheduler,
         }
         components = get_non_null_items(components)
 
-        pipe = FluxPipeline.from_pretrained(
+        pipe = HiDreamImagePipeline.from_pretrained(
             self.pretrained_model_name_or_path, **components, revision=self.revision, cache_dir=self.cache_dir
         )
         pipe.text_encoder.to(self.text_encoder_dtype)
-        pipe.text_encoder_2.to(self.text_encoder_2_dtype)
         pipe.vae.to(self.vae_dtype)
 
         _enable_vae_memory_optimizations(pipe.vae, enable_slicing, enable_tiling)
@@ -243,19 +390,27 @@ class FluxModelSpecification(ModelSpecification):
     @torch.no_grad()
     def prepare_conditions(
         self,
-        tokenizer: AutoTokenizer,
+        tokenizer: CLIPTokenizer,
         tokenizer_2: CLIPTokenizer,
-        text_encoder: CLIPTextModel,
-        text_encoder_2: T5EncoderModel,
+        tokenizer_3: T5Tokenizer,
+        tokenizer_4: AutoTokenizer,
+        text_encoder: CLIPTextModelWithProjection,
+        text_encoder_2: CLIPTextModelWithProjection,
+        text_encoder_3: T5EncoderModel,
+        text_encoder_4: LlamaForCausalLM,
         caption: str,
-        max_sequence_length: int = 512,
+        max_sequence_length: int = 128,
         **kwargs,
     ) -> Dict[str, Any]:
         conditions = {
             "tokenizer": tokenizer,
             "tokenizer_2": tokenizer_2,
+            "tokenizer_3": tokenizer_3,
+            "tokenizer_4": tokenizer_4,
             "text_encoder": text_encoder,
             "text_encoder_2": text_encoder_2,
+            "text_encoder_3": text_encoder_3,
+            "text_encoder_4": text_encoder_4,
             "caption": caption,
             "max_sequence_length": max_sequence_length,
             **kwargs,
@@ -290,7 +445,7 @@ class FluxModelSpecification(ModelSpecification):
 
     def forward(
         self,
-        transformer: FluxTransformer2DModel,
+        transformer: HiDreamImageTransformer2DModel,
         condition_model_conditions: Dict[str, torch.Tensor],
         latent_model_conditions: Dict[str, torch.Tensor],
         sigmas: torch.Tensor,
@@ -312,60 +467,81 @@ class FluxModelSpecification(ModelSpecification):
 
         noise = torch.zeros_like(latents).normal_(generator=generator)
         timesteps = (sigmas.flatten() * 1000.0).long()
-        img_ids = FluxPipeline._prepare_latent_image_ids(
-            latents.size(0), latents.size(2) // 2, latents.size(3) // 2, latents.device, latents.dtype
-        )
-        text_ids = latents.new_zeros(condition_model_conditions["encoder_hidden_states"].shape[1], 3)
-
-        if self.transformer_config.guidance_embeds:
-            guidance_scale = 1.0
-            guidance = latents.new_full((1,), guidance_scale).expand(latents.shape[0])
-        else:
-            guidance = None
-
         noisy_latents = FF.flow_match_xt(latents, noise, sigmas)
-        noisy_latents = FluxPipeline._pack_latents(noisy_latents, *latents.shape)
+
+        batch_size, num_channels, height, width = latents.shape
+        img_sizes = img_ids = None
+        p = self.transformer_config.patch_size
+        if height != width:
+            patch_height, patch_width = height // p, width // p
+
+            img_sizes = torch.tensor([patch_height, patch_width], dtype=torch.int64).reshape(-1)
+            img_ids = torch.zeros(patch_height, patch_width, 3)
+            img_ids[..., 1] = img_ids[..., 1] + torch.arange(patch_height)[:, None]
+            img_ids[..., 2] = img_ids[..., 2] + torch.arange(patch_width)[None, :]
+            img_ids = img_ids.reshape(patch_height * patch_width, -1)
+            img_ids_pad = torch.zeros(self.transformer.max_seq, 3)
+            img_ids_pad[: patch_height * patch_width, :] = img_ids
+
+            img_sizes = img_sizes.unsqueeze(0).to(latents.device)
+            img_ids = img_ids_pad.unsqueeze(0).to(latents.device)
+
+        pooled_prompt_embeds_1 = condition_model_conditions.pop("pooled_prompt_embeds_1")
+        pooled_prompt_embeds_2 = condition_model_conditions.pop("pooled_prompt_embeds_2")
+        pooled_embeds = torch.cat([pooled_prompt_embeds_1, pooled_prompt_embeds_2], dim=-1)
+        encoder_hidden_states_t5 = condition_model_conditions.pop("encoder_hidden_states_t5")
+        encoder_hidden_states_llama = condition_model_conditions.pop("encoder_hidden_states_llama")
+        encoder_hidden_states = [encoder_hidden_states_t5, encoder_hidden_states_llama]
 
         latent_model_conditions["hidden_states"] = noisy_latents.to(latents)
-        condition_model_conditions.pop("prompt_attention_mask", None)
+        latent_model_conditions["encoder_hidden_states"] = encoder_hidden_states
+        latent_model_conditions["pooled_embeds"] = pooled_embeds
+        latent_model_conditions["img_ids"] = img_ids
+        latent_model_conditions["img_sizes"] = img_sizes
 
-        spatial_compression_ratio = 2 ** len(self.vae_config.block_out_channels)
         pred = transformer(
             **latent_model_conditions,
             **condition_model_conditions,
-            timestep=timesteps / 1000.0,
-            guidance=guidance,
-            img_ids=img_ids,
-            txt_ids=text_ids,
+            timesteps=timesteps,
             return_dict=False,
         )[0]
-        pred = FluxPipeline._unpack_latents(
-            pred,
-            latents.size(2) * spatial_compression_ratio,
-            latents.size(3) * spatial_compression_ratio,
-            spatial_compression_ratio,
-        )
+        pred = pred.flatten(-2, -1).unflatten(-1, (height, width))
+        pred = -pred
         target = FF.flow_match_target(noise, latents)
 
         return pred, target, sigmas
 
     def validation(
         self,
-        pipeline: FluxPipeline,
+        pipeline: HiDreamImagePipeline,
         prompt: str,
+        prompt_2: Optional[str] = None,
+        prompt_3: Optional[str] = None,
+        prompt_4: Optional[str] = None,
+        negative_prompt: Optional[str] = None,
+        negative_prompt_2: Optional[str] = None,
+        negative_prompt_3: Optional[str] = None,
+        negative_prompt_4: Optional[str] = None,
         height: Optional[int] = None,
         width: Optional[int] = None,
         num_inference_steps: int = 50,
-        guidance_scale: float = 3.5,
+        guidance_scale: float = 5.0,
         generator: Optional[torch.Generator] = None,
         **kwargs,
     ) -> List[ArtifactType]:
         generation_kwargs = {
             "prompt": prompt,
+            "prompt_2": prompt_2,
+            "prompt_3": prompt_3,
+            "prompt_4": prompt_4,
+            "negative_prompt": negative_prompt,
+            "negative_prompt_2": negative_prompt_2,
+            "negative_prompt_3": negative_prompt_3,
+            "negative_prompt_4": negative_prompt_4,
             "height": height,
             "width": width,
-            "num_inference_steps": num_inference_steps,
             "guidance_scale": guidance_scale,
+            "num_inference_steps": num_inference_steps,
             "generator": generator,
             "return_dict": True,
             "output_type": "pil",
@@ -385,7 +561,7 @@ class FluxModelSpecification(ModelSpecification):
     ) -> None:
         # TODO(aryan): this needs refactoring
         if transformer_state_dict is not None:
-            FluxPipeline.save_lora_weights(
+            HiDreamImagePipeline.save_lora_weights(
                 directory,
                 transformer_state_dict,
                 save_function=functools.partial(safetensors_torch_save_function, metadata=metadata),
@@ -397,14 +573,14 @@ class FluxModelSpecification(ModelSpecification):
     def _save_model(
         self,
         directory: str,
-        transformer: FluxTransformer2DModel,
+        transformer: HiDreamImageTransformer2DModel,
         transformer_state_dict: Optional[Dict[str, torch.Tensor]] = None,
         scheduler: Optional[SchedulerType] = None,
     ) -> None:
         # TODO(aryan): this needs refactoring
         if transformer_state_dict is not None:
             with init_empty_weights():
-                transformer_copy = FluxTransformer2DModel.from_config(transformer.config)
+                transformer_copy = HiDreamImageTransformer2DModel.from_config(transformer.config)
             transformer_copy.load_state_dict(transformer_state_dict, strict=True, assign=True)
             transformer_copy.save_pretrained(os.path.join(directory, "transformer"))
         if scheduler is not None:

--- a/finetrainers/models/hunyuan_video/base_specification.py
+++ b/finetrainers/models/hunyuan_video/base_specification.py
@@ -17,7 +17,7 @@ import finetrainers.functional as FF
 from finetrainers.data import VideoArtifact
 from finetrainers.logging import get_logger
 from finetrainers.models.modeling_utils import ModelSpecification
-from finetrainers.processors import CLIPPooledProcessor, LlamaProcessor, ProcessorMixin
+from finetrainers.processors import CLIPTextModelPooledProcessor, LlamaProcessor, ProcessorMixin
 from finetrainers.typing import ArtifactType, SchedulerType
 from finetrainers.utils import _enable_vae_memory_optimizations, get_non_null_items, safetensors_torch_save_function
 
@@ -109,7 +109,7 @@ class HunyuanVideoModelSpecification(ModelSpecification):
         if condition_model_processors is None:
             condition_model_processors = [
                 LlamaProcessor(["encoder_hidden_states", "encoder_attention_mask"]),
-                CLIPPooledProcessor(
+                CLIPTextModelPooledProcessor(
                     ["pooled_projections"],
                     input_names={"tokenizer_2": "tokenizer", "text_encoder_2": "text_encoder"},
                 ),

--- a/finetrainers/models/modeling_utils.py
+++ b/finetrainers/models/modeling_utils.py
@@ -36,14 +36,17 @@ class ModelSpecification:
         tokenizer_id: Optional[str] = None,
         tokenizer_2_id: Optional[str] = None,
         tokenizer_3_id: Optional[str] = None,
+        tokenizer_4_id: Optional[str] = None,
         text_encoder_id: Optional[str] = None,
         text_encoder_2_id: Optional[str] = None,
         text_encoder_3_id: Optional[str] = None,
+        text_encoder_4_id: Optional[str] = None,
         transformer_id: Optional[str] = None,
         vae_id: Optional[str] = None,
         text_encoder_dtype: torch.dtype = torch.bfloat16,
         text_encoder_2_dtype: torch.dtype = torch.bfloat16,
         text_encoder_3_dtype: torch.dtype = torch.bfloat16,
+        text_encoder_4_dtype: torch.dtype = torch.bfloat16,
         transformer_dtype: torch.dtype = torch.bfloat16,
         vae_dtype: str = torch.bfloat16,
         revision: Optional[str] = None,
@@ -55,14 +58,17 @@ class ModelSpecification:
         self.tokenizer_id = tokenizer_id
         self.tokenizer_2_id = tokenizer_2_id
         self.tokenizer_3_id = tokenizer_3_id
+        self.tokenizer_4_id = tokenizer_4_id
         self.text_encoder_id = text_encoder_id
         self.text_encoder_2_id = text_encoder_2_id
         self.text_encoder_3_id = text_encoder_3_id
+        self.text_encoder_4_id = text_encoder_4_id
         self.transformer_id = transformer_id
         self.vae_id = vae_id
         self.text_encoder_dtype = text_encoder_dtype
         self.text_encoder_2_dtype = text_encoder_2_dtype
         self.text_encoder_3_dtype = text_encoder_3_dtype
+        self.text_encoder_4_dtype = text_encoder_4_dtype
         self.transformer_dtype = transformer_dtype
         self.vae_dtype = vae_dtype
         self.revision = revision
@@ -105,9 +111,11 @@ class ModelSpecification:
         tokenizer: Optional[TokenizerType] = None,
         tokenizer_2: Optional[TokenizerType] = None,
         tokenizer_3: Optional[TokenizerType] = None,
+        tokenizer_4: Optional[TokenizerType] = None,
         text_encoder: Optional[torch.nn.Module] = None,
         text_encoder_2: Optional[torch.nn.Module] = None,
         text_encoder_3: Optional[torch.nn.Module] = None,
+        text_encoder_4: Optional[torch.nn.Module] = None,
         transformer: Optional[torch.nn.Module] = None,
         vae: Optional[torch.nn.Module] = None,
         scheduler: Optional[SchedulerType] = None,
@@ -237,6 +245,7 @@ class ModelSpecification:
         text_encoder: torch.nn.Module,
         text_encoder_2: torch.nn.Module,
         text_encoder_3: torch.nn.Module,
+        text_encoder_4: torch.nn.Module,
         transformer: torch.nn.Module,
         vae: torch.nn.Module,
     ) -> None:

--- a/finetrainers/models/wan/base_specification.py
+++ b/finetrainers/models/wan/base_specification.py
@@ -108,7 +108,9 @@ class WanModelSpecification(ModelSpecification):
         )
 
         if condition_model_processors is None:
-            condition_model_processors = [T5Processor(["encoder_hidden_states", "prompt_attention_mask"])]
+            condition_model_processors = [
+                T5Processor(["encoder_hidden_states", "prompt_attention_mask"], use_attention_mask=True)
+            ]
         if latent_model_processors is None:
             latent_model_processors = [WanLatentEncodeProcessor(["latents", "latents_mean", "latents_std"])]
 

--- a/finetrainers/processors/__init__.py
+++ b/finetrainers/processors/__init__.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from .base import ProcessorMixin
 from .canny import CannyProcessor
-from .clip import CLIPPooledProcessor
+from .clip import CLIPTextModelPooledProcessor, CLIPTextModelWithProjectionPooledProcessor
 from .glm import CogView4GLMProcessor
 from .llama import LlamaProcessor
 from .t5 import T5Processor

--- a/finetrainers/processors/clip.py
+++ b/finetrainers/processors/clip.py
@@ -6,10 +6,10 @@ from transformers import CLIPTextModel, CLIPTokenizer, CLIPTokenizerFast
 from .base import ProcessorMixin
 
 
-class CLIPPooledProcessor(ProcessorMixin):
+class CLIPTextModelPooledProcessor(ProcessorMixin):
     r"""
-    Processor for the Llama family of models. This processor is used to encode text inputs and return the embeddings
-    and attention masks for the input text.
+    Processor for the CLIPTextModel family of models. This processor is used to encode text inputs and return the embeddings
+    and attention masks for the input text. This processor is specific to retrieving the pooled output.
 
     Args:
         output_names (`List[str]`):
@@ -37,7 +37,7 @@ class CLIPPooledProcessor(ProcessorMixin):
         Args:
             tokenizer (`Union[LlamaTokenizer, LlamaTokenizerFast]`):
                 The tokenizer used to tokenize the input text.
-            text_encoder (`LlamaModel`):
+            text_encoder (`CLIPTextModel`):
                 The text encoder used to encode the input text.
             caption (`Union[str, List[str]]`):
                 The input text to be encoded.
@@ -58,6 +58,64 @@ class CLIPPooledProcessor(ProcessorMixin):
         text_input_ids = text_inputs.input_ids.to(device)
 
         prompt_embeds = text_encoder(text_input_ids, output_hidden_states=False).pooler_output
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+
+        return {self.output_names[0]: prompt_embeds}
+
+
+class CLIPTextModelWithProjectionPooledProcessor(ProcessorMixin):
+    r"""
+    Processor for the CLIPTextModelWithProjection family of models. This processor is used to encode text inputs
+    and return the embeddings and attention masks for the input text. This processor is specific to retrieving the
+    pooled output.
+
+    Args:
+        output_names (`List[str]`):
+            The names of the outputs that the processor should return. The first output is the embeddings of the input
+            text and the second output is the attention mask for the input text.
+    """
+
+    def __init__(self, output_names: List[str] = None, input_names: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__()
+
+        self.output_names = output_names
+        self.input_names = input_names
+
+        assert len(output_names) == 1
+
+    def forward(
+        self,
+        tokenizer: Union[CLIPTokenizer, CLIPTokenizerFast],
+        text_encoder: CLIPTextModel,
+        caption: Union[str, List[str]],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        r"""
+        Encode the input text and return the embeddings and attention mask for the input text.
+
+        Args:
+            tokenizer (`Union[LlamaTokenizer, LlamaTokenizerFast]`):
+                The tokenizer used to tokenize the input text.
+            text_encoder (`CLIPTextModel`):
+                The text encoder used to encode the input text.
+            caption (`Union[str, List[str]]`):
+                The input text to be encoded.
+        """
+        if isinstance(caption, str):
+            caption = [caption]
+
+        device = text_encoder.device
+        dtype = text_encoder.dtype
+
+        text_inputs = tokenizer(
+            caption,
+            padding="max_length",
+            max_length=77,
+            truncation=True,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids.to(device)
+
+        prompt_embeds = text_encoder(text_input_ids, output_hidden_states=False).text_embeds
         prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
 
         return {self.output_names[0]: prompt_embeds}

--- a/finetrainers/processors/t5.py
+++ b/finetrainers/processors/t5.py
@@ -17,14 +17,16 @@ class T5Processor(ProcessorMixin):
             text and the second output is the attention mask for the input text.
     """
 
-    def __init__(self, output_names: List[str], input_names: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self, output_names: List[str], input_names: Optional[Dict[str, Any]] = None, use_attention_mask: bool = False
+    ):
         super().__init__()
 
         self.output_names = output_names
         self.input_names = input_names
-        if input_names is not None:
-            assert len(input_names) <= 4
+        self.use_attention_mask = use_attention_mask
 
+        assert input_names is None or len(input_names) <= 4
         assert len(self.output_names) == 2
 
     def forward(
@@ -65,8 +67,13 @@ class T5Processor(ProcessorMixin):
         text_input_ids = text_inputs.input_ids
         prompt_attention_mask = text_inputs.attention_mask
         prompt_attention_mask = prompt_attention_mask.bool().to(device)
+        text_input_ids = text_input_ids.to(device)
 
-        prompt_embeds = text_encoder(text_input_ids.to(device))[0]
+        if self.use_attention_mask:
+            prompt_embeds = text_encoder(text_input_ids, attention_mask=prompt_attention_mask)[0]
+        else:
+            prompt_embeds = text_encoder(text_input_ids)[0]
+
         prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
         prompt_attention_mask = prompt_attention_mask.view(batch_size, -1)
 

--- a/finetrainers/trainer/sft_trainer/trainer.py
+++ b/finetrainers/trainer/sft_trainer/trainer.py
@@ -36,8 +36,8 @@ logger = logging.get_logger()
 
 class SFTTrainer:
     # fmt: off
-    _all_component_names = ["tokenizer", "tokenizer_2", "tokenizer_3", "text_encoder", "text_encoder_2", "text_encoder_3", "transformer", "unet", "vae", "scheduler"]
-    _condition_component_names = ["tokenizer", "tokenizer_2", "tokenizer_3", "text_encoder", "text_encoder_2", "text_encoder_3"]
+    _all_component_names = ["tokenizer", "tokenizer_2", "tokenizer_3", "tokenizer_4", "text_encoder", "text_encoder_2", "text_encoder_3", "text_encoder_4", "transformer", "unet", "vae", "scheduler"]
+    _condition_component_names = ["tokenizer", "tokenizer_2", "tokenizer_3", "tokenizer_4", "text_encoder", "text_encoder_2", "text_encoder_3", "text_encoder_4"]
     _latent_component_names = ["vae"]
     _diffusion_component_names = ["transformer", "unet", "scheduler"]
     # fmt: on
@@ -51,11 +51,13 @@ class SFTTrainer:
         self.tokenizer = None
         self.tokenizer_2 = None
         self.tokenizer_3 = None
+        self.tokenizer_4 = None
 
         # Text encoders
         self.text_encoder = None
         self.text_encoder_2 = None
         self.text_encoder_3 = None
+        self.text_encoder_4 = None
 
         # Denoisers
         self.transformer = None
@@ -699,7 +701,7 @@ class SFTTrainer:
         logger.info(f"Memory after validation end: {json.dumps(memory_statistics, indent=4)}")
 
         # Remove all hooks that might have been added during pipeline initialization to the models
-        module_names = ["text_encoder", "text_encoder_2", "text_encoder_3", "vae"]
+        module_names = ["text_encoder", "text_encoder_2", "text_encoder_3", "text_encoder_4", "vae"]
         pipeline.remove_all_hooks()
         del pipeline
         if self.args.enable_precomputation:
@@ -799,7 +801,14 @@ class SFTTrainer:
         if device is None:
             device = self.state.parallel_backend.device
         if components is None:
-            components = [self.text_encoder, self.text_encoder_2, self.text_encoder_3, self.transformer, self.vae]
+            components = [
+                self.text_encoder,
+                self.text_encoder_2,
+                self.text_encoder_3,
+                self.text_encoder_4,
+                self.transformer,
+                self.vae,
+            ]
         components = utils.get_non_null_items(components)
         components = list(filter(lambda x: hasattr(x, "to"), components))
         for component in components:
@@ -820,7 +829,7 @@ class SFTTrainer:
         utils.synchronize_device()
 
     def _init_pipeline(self, final_validation: bool = False) -> DiffusionPipeline:
-        module_names = ["text_encoder", "text_encoder_2", "text_encoder_3", "transformer", "vae"]
+        module_names = ["text_encoder", "text_encoder_2", "text_encoder_3", "text_encoder_4", "transformer", "vae"]
 
         if not final_validation:
             module_names.remove("transformer")
@@ -828,9 +837,11 @@ class SFTTrainer:
                 tokenizer=self.tokenizer,
                 tokenizer_2=self.tokenizer_2,
                 tokenizer_3=self.tokenizer_3,
+                tokenizer_4=self.tokenizer_4,
                 text_encoder=self.text_encoder,
                 text_encoder_2=self.text_encoder_2,
                 text_encoder_3=self.text_encoder_3,
+                text_encoder_4=self.text_encoder_4,
                 # TODO(aryan): handle unwrapping for compiled modules
                 # transformer=utils.unwrap_model(accelerator, self.transformer),
                 transformer=self.transformer,

--- a/tests/models/hidream/base_specification.py
+++ b/tests/models/hidream/base_specification.py
@@ -1,0 +1,12 @@
+from finetrainers.models.hidream import HiDreamImageModelSpecification
+
+
+class DummyHiDreamImageModelSpecification(HiDreamImageModelSpecification):
+    def __init__(self, **kwargs):
+        super().__init__(
+            pretrained_model_name_or_path="./dump_hidream_pipeline",
+            # This is passed separately so that AutoTokenizer can load T5TokenizerFast instead of the BaseSpec's
+            # T5Tokenier from the internal testing repo.
+            tokenizer_3_id="hf-internal-testing/tiny-random-t5",
+            **kwargs,
+        )

--- a/tests/trainer/test_sft_trainer.py
+++ b/tests/trainer/test_sft_trainer.py
@@ -22,6 +22,7 @@ os.environ["FINETRAINERS_LOG_LEVEL"] = "INFO"
 from ..models.cogvideox.base_specification import DummyCogVideoXModelSpecification  # noqa
 from ..models.cogview4.base_specification import DummyCogView4ModelSpecification  # noqa
 from ..models.flux.base_specification import DummyFluxModelSpecification  # noqa
+from ..models.hidream.base_specification import DummyHiDreamImageModelSpecification  # noqa
 from ..models.hunyuan_video.base_specification import DummyHunyuanVideoModelSpecification  # noqa
 from ..models.ltx_video.base_specification import DummyLTXVideoModelSpecification  # noqa
 from ..models.wan.base_specification import DummyWanModelSpecification  # noqa
@@ -459,6 +460,14 @@ class SFTTrainerFluxLoRATests___PTD(SFTTrainerLoRATestsMixin___PTD, unittest.Tes
 
 class SFTTrainerFluxFullFinetuneTests___PTD(SFTTrainerFullFinetuneTestsMixin___PTD, unittest.TestCase):
     model_specification_cls = DummyFluxModelSpecification
+
+
+class SFTTrainerHiDreamImageLoRATests___PTD(SFTTrainerLoRATestsMixin___PTD, unittest.TestCase):
+    model_specification_cls = DummyHiDreamImageModelSpecification
+
+
+class SFTTrainerHiDreamImageFullFinetuneTests___PTD(SFTTrainerFullFinetuneTestsMixin___PTD, unittest.TestCase):
+    model_specification_cls = DummyHiDreamImageModelSpecification
 
 
 class SFTTrainerHunyuanVideoLoRATests___PTD(SFTTrainerLoRATestsMixin___PTD, unittest.TestCase):


### PR DESCRIPTION
This PR adds support for training HiDream-Image using the Diffusers adaptation. Additionally, take a look at the Diffusers Trainer: https://github.com/huggingface/diffusers/pull/11281

Currently, only the Full and Dev checkpoints are supported:
- https://huggingface.co/HiDream-ai/HiDream-I1-Full
- https://huggingface.co/HiDream-ai/HiDream-I1-Dev

For training "Fast", extensive testing with timestep schedules (possibly LADD) are required, so it is not going to be covered in this PR.

Note: This PR is a work-in-progress and may not work as intended yet!