### PR TITLE
Fix precomputation-related file deletion when starting new runs

### DIFF
--- a/finetrainers/data/precomputation.py
+++ b/finetrainers/data/precomputation.py
@@ -144,10 +144,8 @@ class PrecomputedDistributedDataPreprocessor(DistributedDataProcessorMixin):
         self._cached_samples = []
         self._preprocessed_iterator: Union["PrecomputedDataIterable", "PrecomputedOnceDataIterable"] = None
 
+        delete_files([self._save_dir])
         self._save_dir.mkdir(parents=True, exist_ok=True)
-
-        subdirectories = [f for f in self._save_dir.iterdir() if f.is_dir()]
-        delete_files(subdirectories)
 
     def consume(
         self,


### PR DESCRIPTION
Fixes the original issue as mentioned in #348.

The problem comes from the older precomputed files not getting cleaned up as is expected from the code behaviour. It is due to a simple mismatch of how the paths were configured after the last round of refactoring